### PR TITLE
Use `go build` instead of `go install`

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -132,9 +132,6 @@ jobs:
             done
             echo "}"
             echo
-            echo "-- Current version of go main package"
-            echo "M.version = \"$(git rev-parse HEAD)\""
-            echo
             echo "return M"
           } > "$MANIFEST_FILE"
       - name: Commit the Generated File

--- a/lua/dbee/install/init.lua
+++ b/lua/dbee/install/init.lua
@@ -14,6 +14,10 @@ function M.path()
   return vim.fn.stdpath("data") .. "/dbee/bin"
 end
 
+function M.source_path()
+  return debug.getinfo(1).source:sub(2):gsub("/lua/dbee/install/init.lua$", "/dbee")
+end
+
 ---@param osys string operating system in format of uv.os_uname()
 ---@param arch string architecture in format of uv.os_uname()
 ---@return string url address of compiled binary
@@ -57,18 +61,6 @@ local function get_url(osys, arch)
   end
 
   return url
-end
-
----@return string version
-local function get_version()
-  local version = "latest"
-  local ok, m = pcall(require, "dbee.install.__manifest")
-  if not ok or type(m) ~= "table" or vim.tbl_isempty(m) then
-    log_error("could not read install manifest. using version: " .. version)
-    return version
-  end
-
-  return m.version or version
 end
 
 ---@param command? install_command
@@ -123,8 +115,8 @@ local function get_job(command)
       return {
         {
           cmd = "go",
-          args = { "install", "github.com/kndndrj/nvim-dbee/dbee@" .. get_version() },
-          env = { GOBIN = install_dir },
+          args = { "build", "-C", M.source_path(), "-o", install_binary },
+          env = {},
         },
       }
     end,
@@ -132,8 +124,8 @@ local function get_job(command)
       return {
         {
           cmd = "go",
-          args = { "install", "github.com/kndndrj/nvim-dbee/dbee@" .. get_version() },
-          env = { GOBIN = install_dir, CGO_ENABLED = "1" },
+          args = { "build", "-C", M.source_path(), "-o", install_binary },
+          env = { CGO_ENABLED = "1" },
         },
       }
     end,

--- a/lua/dbee/install/init.lua
+++ b/lua/dbee/install/init.lua
@@ -10,12 +10,15 @@ local function log_info(mes)
   print("[dbee install]: " .. mes)
 end
 
+---@return string # installation path
 function M.path()
   return vim.fn.stdpath("data") .. "/dbee/bin"
 end
 
+---@return string # path of go source
 function M.source_path()
-  return debug.getinfo(1).source:sub(2):gsub("/lua/dbee/install/init.lua$", "/dbee")
+  local p, _ = debug.getinfo(1).source:sub(2):gsub("/lua/dbee/install/init.lua$", "/dbee")
+  return p
 end
 
 ---@param osys string operating system in format of uv.os_uname()


### PR DESCRIPTION
Doesn't require the CI pipeline to work, and easier to verify that binary matches source code.

~~Not tested on windows, not sure if the path needs to be normalized.~~ Seems to work, at least in Git Bash, and whatever `winget install Neovim.Neovim` installed.