### PR TITLE
Feature/multiple databases

### DIFF
--- a/dbee/clients/bigquery.go
+++ b/dbee/clients/bigquery.go
@@ -178,7 +178,7 @@ func (c *BigQueryClient) Layout() (layouts []models.Layout, err error) {
 			Name:     dataset.DatasetID,
 			Schema:   dataset.DatasetID,
 			Database: dataset.ProjectID,
-			Type:     models.LayoutNone,
+			Type:     models.LayoutTypeNone,
 			Children: []models.Layout{},
 		}
 
@@ -197,7 +197,7 @@ func (c *BigQueryClient) Layout() (layouts []models.Layout, err error) {
 				Name:     table.TableID,
 				Schema:   table.DatasetID,
 				Database: table.ProjectID,
-				Type:     models.LayoutTable,
+				Type:     models.LayoutTypeTable,
 				Children: nil,
 			})
 		}

--- a/dbee/clients/common/client.go
+++ b/dbee/clients/common/client.go
@@ -31,6 +31,11 @@ func (c *Client) Close() {
 	c.db.Close()
 }
 
+func (c *Client) Swap(db *sql.DB) {
+	c.db.Close()
+	c.db = db
+}
+
 // connection to use for execution
 type Conn struct {
 	conn *sql.Conn

--- a/dbee/clients/duckdb.go
+++ b/dbee/clients/duckdb.go
@@ -81,7 +81,7 @@ func (c *DuckClient) Layout() ([]models.Layout, error) {
 			Schema: "",
 			// TODO:
 			Database: "",
-			Type:     models.LayoutTable,
+			Type:     models.LayoutTypeTable,
 		})
 	}
 

--- a/dbee/clients/mongo.go
+++ b/dbee/clients/mongo.go
@@ -160,7 +160,7 @@ func (c *MongoClient) Layout() ([]models.Layout, error) {
 			Name:     coll,
 			Schema:   "",
 			Database: "",
-			Type:     models.LayoutTable,
+			Type:     models.LayoutTypeTable,
 		})
 	}
 

--- a/dbee/clients/oracle.go
+++ b/dbee/clients/oracle.go
@@ -118,7 +118,7 @@ func (c *OracleClient) Layout() ([]models.Layout, error) {
 			Schema: schema,
 			// TODO:
 			Database: "",
-			Type:     models.LayoutTable,
+			Type:     models.LayoutTypeTable,
 		})
 
 	}
@@ -131,7 +131,7 @@ func (c *OracleClient) Layout() ([]models.Layout, error) {
 			Schema: k,
 			// TODO:
 			Database: "",
-			Type:     models.LayoutNone,
+			Type:     models.LayoutTypeNone,
 			Children: v,
 		})
 	}

--- a/dbee/clients/postgres.go
+++ b/dbee/clients/postgres.go
@@ -135,6 +135,10 @@ func (c *PostgresClient) Layout() ([]models.Layout, error) {
 	return layout, nil
 }
 
+func (c *PostgresClient) Close() {
+	c.c.Close()
+}
+
 func (c *PostgresClient) ListDatabases() (current string, available []string, err error) {
 	query := `
 		SELECT current_database(), datname FROM pg_database
@@ -165,19 +169,13 @@ func (c *PostgresClient) ListDatabases() (current string, available []string, er
 }
 
 func (c *PostgresClient) SelectDatabase(name string) error {
-	url := *c.url
-	url.Path = fmt.Sprintf("/%s", name)
-	db, err := sql.Open("postgres", url.String())
+	c.url.Path = fmt.Sprintf("/%s", name)
+	db, err := sql.Open("postgres", c.url.String())
 	if err != nil {
 		return fmt.Errorf("unable to switch databases: %w", err)
 	}
 
-	c.url = &url
 	c.c.Swap(db)
 
 	return nil
-}
-
-func (c *PostgresClient) Close() {
-	c.c.Close()
 }

--- a/dbee/clients/redis.go
+++ b/dbee/clients/redis.go
@@ -117,7 +117,7 @@ func (c *RedisClient) Layout() ([]models.Layout, error) {
 			Name:     "DB",
 			Schema:   "",
 			Database: "",
-			Type:     models.LayoutTable,
+			Type:     models.LayoutTypeTable,
 		},
 	}, nil
 }

--- a/dbee/clients/sqlite.go
+++ b/dbee/clients/sqlite.go
@@ -95,7 +95,7 @@ func (c *SqliteClient) Layout() ([]models.Layout, error) {
 			Schema: "",
 			// TODO:
 			Database: "",
-			Type:     models.LayoutTable,
+			Type:     models.LayoutTypeTable,
 		})
 	}
 

--- a/dbee/clients/sqlserver.go
+++ b/dbee/clients/sqlserver.go
@@ -97,7 +97,7 @@ func (c *SQLServerClient) Layout() ([]models.Layout, error) {
 			Schema: schema,
 			// TODO:
 			Database: "",
-			Type:     models.LayoutTable,
+			Type:     models.LayoutTypeTable,
 		})
 
 	}
@@ -110,7 +110,7 @@ func (c *SQLServerClient) Layout() ([]models.Layout, error) {
 			Schema: k,
 			// TODO:
 			Database: "",
-			Type:     models.LayoutNone,
+			Type:     models.LayoutTypeNone,
 			Children: v,
 		})
 	}

--- a/dbee/clients/sqlserver.go
+++ b/dbee/clients/sqlserver.go
@@ -3,6 +3,7 @@ package clients
 import (
 	"database/sql"
 	"fmt"
+	nurl "net/url"
 
 	"github.com/kndndrj/nvim-dbee/dbee/clients/common"
 	"github.com/kndndrj/nvim-dbee/dbee/conn"
@@ -20,17 +21,24 @@ func init() {
 }
 
 type SQLServerClient struct {
-	c *common.Client
+	c   *common.Client
+	url *nurl.URL
 }
 
 func NewSQLServer(url string) (*SQLServerClient, error) {
-	db, err := sql.Open("sqlserver", url)
+	u, err := nurl.Parse(url)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse db connection string: %w: ", err)
+	}
+
+	db, err := sql.Open("sqlserver", u.String())
 	if err != nil {
 		return nil, fmt.Errorf("unable to connect to sqlserver database: %v", err)
 	}
 
 	return &SQLServerClient{
-		c: common.NewClient(db),
+		c:   common.NewClient(db),
+		url: u,
 	}, nil
 }
 
@@ -120,4 +128,48 @@ func (c *SQLServerClient) Layout() ([]models.Layout, error) {
 
 func (c *SQLServerClient) Close() {
 	c.c.Close()
+}
+
+func (c *SQLServerClient) ListDatabases() (current string, available []string, err error) {
+	query := `
+		SELECT DB_NAME(), name
+		FROM sys.databases
+		WHERE name != DB_NAME();
+	`
+
+	rows, err := c.Query(query)
+	if err != nil {
+		return "", nil, err
+	}
+
+	for {
+		row, err := rows.Next()
+		if row == nil {
+			break
+		}
+		if err != nil {
+			return "", nil, err
+		}
+
+		// We know for a fact there are 2 string fields (see query above)
+		current = row[0].(string)
+		available = append(available, row[1].(string))
+	}
+
+	return current, available, nil
+}
+
+func (c *SQLServerClient) SelectDatabase(name string) error {
+	q := c.url.Query()
+	q.Set("database", name)
+	c.url.RawQuery = q.Encode()
+
+	db, err := sql.Open("sqlserver", c.url.String())
+	if err != nil {
+		return fmt.Errorf("unable to switch databases: %w", err)
+	}
+
+	c.c.Swap(db)
+
+	return nil
 }

--- a/dbee/conn/conn.go
+++ b/dbee/conn/conn.go
@@ -167,7 +167,7 @@ func (c *Conn) Layout() ([]models.Layout, error) {
 		}
 
 		layout = append(layout, models.Layout{
-			Name:      "DB: " + currentDB,
+			Name:      currentDB,
 			Type:      models.LayoutTypeDatabaseSwitch,
 			PickItems: availableDBs,
 		})

--- a/dbee/conn/conn.go
+++ b/dbee/conn/conn.go
@@ -160,9 +160,11 @@ func (c *Conn) Layout() ([]models.Layout, error) {
 			return nil, err
 		}
 
-		dbLayout := models.NewListLayout("DB: "+currentDB, availableDBs)
-		dbLayout.Type = models.LayoutTypeDatabaseSwitch
-		layout = append(layout, dbLayout)
+		layout = append(layout, models.Layout{
+			Name:      "DB: " + currentDB,
+			Type:      models.LayoutTypeDatabaseSwitch,
+			PickItems: availableDBs,
+		})
 	}
 
 	return layout, nil

--- a/dbee/conn/history.go
+++ b/dbee/conn/history.go
@@ -217,19 +217,19 @@ func (ho *HistoryOutput) Layout() ([]models.Layout, error) {
 			Name:     strconv.Itoa(int(key)),
 			Schema:   "",
 			Database: "",
-			Type:     models.LayoutHistory,
+			Type:     models.LayoutTypeHistory,
 			Children: []models.Layout{
 				{
 					Name:     rec.meta.Timestamp.String(),
 					Schema:   "",
 					Database: "",
-					Type:     models.LayoutNone,
+					Type:     models.LayoutTypeNone,
 				},
 				{
 					Name:     rec.meta.Query,
 					Schema:   "",
 					Database: "",
-					Type:     models.LayoutNone,
+					Type:     models.LayoutTypeNone,
 				},
 			},
 		}

--- a/dbee/main.go
+++ b/dbee/main.go
@@ -181,6 +181,35 @@ func main() {
 				return nil
 			})
 
+		p.HandleFunction(&plugin.FunctionOptions{Name: "Dbee_switch_database"},
+			func(args []string) error {
+				method := "Dbee_switch_database"
+				logger.Debug("calling " + method)
+				if len(args) < 2 {
+					logger.Error("not enough arguments passed to " + method)
+					return nil
+				}
+
+				id := args[0]
+				name := args[1]
+
+				// Get the right connection
+				c, ok := connections[id]
+				if !ok {
+					logger.Error("connection with id " + id + " not registered")
+					return nil
+				}
+
+				err := c.SwitchDatabase(name)
+				if err != nil {
+					logger.Error(err.Error())
+					return nil
+				}
+
+				logger.Debug(method + " returned successfully")
+				return nil
+			})
+
 		// pages result to buffer output, returns total number of rows
 		p.HandleFunction(&plugin.FunctionOptions{Name: "Dbee_get_current_result"},
 			func(args []string) (int, error) {

--- a/dbee/models/layout.go
+++ b/dbee/models/layout.go
@@ -2,33 +2,54 @@ package models
 
 import "encoding/json"
 
-type (
-	LayoutType int
-	// Layout is a dict which represents a database structure
-	// it's primarely used for the tree view
-	Layout struct {
-		Name     string     `json:"name"`
-		Schema   string     `json:"schema"`
-		Database string     `json:"database"`
-		Type     LayoutType `json:"type"`
-		Children []Layout   `json:"children"`
-	}
-)
+type LayoutType int
 
 const (
-	LayoutNone LayoutType = iota
-	LayoutTable
-	LayoutHistory
+	LayoutTypeNone LayoutType = iota
+	LayoutTypeTable
+	LayoutTypeHistory
+	LayoutTypeDatabaseSwitch
 )
+
+// Layout is a dict which represents a database structure
+// it's primarely used for the tree view
+type Layout struct {
+	// Name to be displayed
+	Name     string `json:"name"`
+	Schema   string `json:"schema"`
+	Database string `json:"database"`
+	// Type of layout
+	Type LayoutType `json:"type"`
+	// Children layout nodes
+	Children []Layout `json:"children"`
+}
+
+// NewListLayout converts a list of strings to layout
+func NewListLayout(parentName string, list []string) Layout {
+	children := make([]Layout, len(list))
+	for i := range list {
+		children[i] = Layout{
+			Name: list[i],
+		}
+	}
+
+	return Layout{
+		Name:     parentName,
+		Type:     LayoutTypeNone,
+		Children: children,
+	}
+}
 
 func (s LayoutType) String() string {
 	switch s {
-	case LayoutNone:
+	case LayoutTypeNone:
 		return ""
-	case LayoutTable:
+	case LayoutTypeTable:
 		return "table"
-	case LayoutHistory:
+	case LayoutTypeHistory:
 		return "history"
+	case LayoutTypeDatabaseSwitch:
+		return "database_switch"
 	default:
 		return ""
 	}

--- a/dbee/models/layout.go
+++ b/dbee/models/layout.go
@@ -15,29 +15,15 @@ const (
 // it's primarely used for the tree view
 type Layout struct {
 	// Name to be displayed
-	Name     string `json:"name"`
-	Schema   string `json:"schema"`
-	Database string `json:"database"`
+	Name     string
+	Schema   string
+	Database string
 	// Type of layout
-	Type LayoutType `json:"type"`
+	Type LayoutType
 	// Children layout nodes
-	Children []Layout `json:"children"`
-}
-
-// NewListLayout converts a list of strings to layout
-func NewListLayout(parentName string, list []string) Layout {
-	children := make([]Layout, len(list))
-	for i := range list {
-		children[i] = Layout{
-			Name: list[i],
-		}
-	}
-
-	return Layout{
-		Name:     parentName,
-		Type:     LayoutTypeNone,
-		Children: children,
-	}
+	Children []Layout
+	// PickItems represents a list of selections (example: database names)
+	PickItems []string
 }
 
 func (s LayoutType) String() string {
@@ -57,16 +43,18 @@ func (s LayoutType) String() string {
 
 func (s *Layout) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
-		Name     string   `json:"name"`
-		Schema   string   `json:"schema"`
-		Database string   `json:"database"`
-		Type     string   `json:"type"`
-		Children []Layout `json:"children"`
+		Name      string   `json:"name"`
+		Schema    string   `json:"schema"`
+		Database  string   `json:"database"`
+		Type      string   `json:"type"`
+		Children  []Layout `json:"children"`
+		PickItems []string `json:"pick_items"`
 	}{
-		Name:     s.Name,
-		Schema:   s.Schema,
-		Database: s.Database,
-		Type:     s.Type.String(),
-		Children: s.Children,
+		Name:      s.Name,
+		Schema:    s.Schema,
+		Database:  s.Database,
+		Type:      s.Type.String(),
+		Children:  s.Children,
+		PickItems: s.PickItems,
 	})
 }

--- a/doc/dbee.txt
+++ b/doc/dbee.txt
@@ -180,9 +180,13 @@ Here are the defaults:
             icon = "",
             icon_highlight = "Character",
           },
-          database = {
-            icon = "",
+          connection = {
+            icon = "󱘖",
             icon_highlight = "SpecialChar",
+          },
+          database_switch = {
+            icon = "",
+            icon_highlight = "Character",
           },
           table = {
             icon = "",

--- a/lua/dbee/config.lua
+++ b/lua/dbee/config.lua
@@ -80,12 +80,12 @@ M.default = {
         icon = "",
         icon_highlight = "Character",
       },
-      database = {
-        icon = "",
+      connection = {
+        icon = "󱘖",
         icon_highlight = "SpecialChar",
       },
       database_switch = {
-        icon = "",
+        icon = "",
         icon_highlight = "Character",
       },
       table = {

--- a/lua/dbee/config.lua
+++ b/lua/dbee/config.lua
@@ -84,6 +84,10 @@ M.default = {
         icon = "",
         icon_highlight = "SpecialChar",
       },
+      database_switch = {
+        icon = "",
+        icon_highlight = "Character",
+      },
       table = {
         icon = "",
         icon_highlight = "Conditional",

--- a/lua/dbee/drawer.lua
+++ b/lua/dbee/drawer.lua
@@ -10,13 +10,14 @@ local utils = require("dbee.utils")
 ---@class Layout
 ---@field id string unique identifier
 ---@field name string display name
----@field type ""|"table"|"history"|"scratch"|"database"|"add"|"edit"|"remove"|"help"|"source" type of layout
+---@field type ""|"table"|"history"|"scratch"|"database"|"database_switch"|"add"|"edit"|"remove"|"help"|"source" type of layout
 ---@field schema? string parent schema
 ---@field database? string parent database
+---@field on_pick? fun(selection: string, cb: fun()) if present, children nodes are treated as values for selection menu (children are shown in the selection menu)
 ---@field action_1? fun(cb: fun()) primary action - takes single arg: callback closure
 ---@field action_2? fun(cb: fun()) secondary action - takes single arg: callback closure
 ---@field action_3? fun(cb: fun()) tertiary action - takes single arg: callback closure
----@field children? Layout[]|fun():Layout[] child layout nodes
+---@field children? Layout[]|fun():Layout[ ] child layout nodes
 ---@field default_expand? Once expand on startup? - basically a bool
 
 -- node is Layout converted to NuiTreeNode
@@ -87,7 +88,7 @@ function Drawer:create_tree(bufnr)
 
       line:append(string.rep("  ", node:get_depth() - 1))
 
-      if node:has_children() or node.getter then
+      if (node:has_children() or node.getter) and node.on_pick == nil then
         local candy = self.candies["node_closed"] or { icon = ">", icon_highlight = "NonText" }
         if node:is_expanded() then
           candy = self.candies["node_expanded"] or { icon = "v", icon_highlight = "NonText" }
@@ -133,6 +134,16 @@ function Drawer:create_tree(bufnr)
   }
 end
 
+---@param children Layout[]
+---@return string[] # list of child layout names
+local function layout_children_to_list(children)
+  local list = {}
+  for _, l in ipairs(children) do
+    table.insert(list, l.name)
+  end
+  return list
+end
+
 ---@private
 ---@param mappings table<string, mapping>
 ---@return keymap[]
@@ -154,6 +165,24 @@ function Drawer:generate_keymap(mappings)
         nested_node:expand()
         expand_all_single(nested_node)
       end
+    end
+
+    -- if on_pick field is present, show the menu with it's children and trigger callback
+    if type(node.on_pick) == "function" then
+      if #node.children < 1 then
+        return
+      end
+
+      vim.ui.select(layout_children_to_list(node.children), {
+        prompt = "pick a " .. node.name .. ":",
+      }, function(selection)
+        if selection then
+          node.on_pick(selection, function()
+            self:refresh()
+          end)
+        end
+      end)
+      return
     end
 
     local expanded = node:is_expanded()
@@ -184,6 +213,8 @@ function Drawer:generate_keymap(mappings)
           node.action_1(function()
             self:refresh()
           end)
+        else
+          expand_node(node)
         end
       end,
       mapping = mappings["action_1"],

--- a/lua/dbee/editor.lua
+++ b/lua/dbee/editor.lua
@@ -170,15 +170,13 @@ function Editor:layout()
           cb()
         end)
       end,
-      action_3 = function(cb)
-        local file = self.scratches[s.id].file
-        vim.ui.input({ prompt = 'confirm deletion of "' .. file .. '"', default = "Y" }, function(input)
-          if not input or string.lower(input) ~= "y" then
-            return
-          end
+      pick_title = "Confirm Deletion",
+      pick_items = { "Yes", "No" },
+      action_3 = function(cb, selection)
+        if selection == "Yes" then
           self:delete_scratch(s.id)
-          cb()
-        end)
+        end
+        cb()
       end,
     }
     table.insert(scratches, sch)

--- a/lua/dbee/handler/conn.lua
+++ b/lua/dbee/handler/conn.lua
@@ -220,7 +220,7 @@ function Conn:layout()
 
     -- sort keys
     table.sort(layout_go, function(k1, k2)
-      return k1.name < k2.name
+      return k1.type .. k1.name < k2.type .. k2.name
     end)
 
     local new_layouts = {}
@@ -241,22 +241,24 @@ function Conn:layout()
       }
 
       if lgo.type == "table" then
-        ly.on_pick = function(selection, cb)
+        ly.action_1 = function(cb, selection)
           local helpers = self.helpers:get(self.type, { table = lgo.name, schema = lgo.schema, dbname = lgo.database })
           self:execute(helpers[selection], cb)
         end
         ly.pick_items = function()
           return self.helpers:list(self.type)
         end
+        ly.pick_title = "Select a Query"
       elseif lgo.type == "history" then
         ly.action_1 = function(cb)
           self:history(lgo.name, cb)
         end
       elseif lgo.type == "database_switch" then
-        ly.on_pick = function(selection, cb)
+        ly.action_1 = function(cb, selection)
           self:switch_database(selection)
           cb()
         end
+        ly.pick_title = "Select a Database"
       end
 
       table.insert(new_layouts, ly)

--- a/lua/dbee/handler/conn_mock.lua
+++ b/lua/dbee/handler/conn_mock.lua
@@ -55,6 +55,10 @@ function MockConn:history(history_id, cb)
   cb()
 end
 
+function MockConn:switch_database(name)
+  print("trying to switch to database: " .. name .. " on a mocked connection")
+end
+
 function MockConn:page_next()
   self.on_exec()
 end

--- a/lua/dbee/handler/helpers.lua
+++ b/lua/dbee/handler/helpers.lua
@@ -328,4 +328,12 @@ function Helpers:add(helpers)
   self.extras = vim.tbl_deep_extend("force", self.extras, ext)
 end
 
+---@param type string
+---@return string[] # list of available table helpers for given type
+function Helpers:list(type)
+  local helpers = self:get(type, {})
+
+  return utils.sorted_keys(helpers)
+end
+
 return Helpers

--- a/lua/dbee/handler/init.lua
+++ b/lua/dbee/handler/init.lua
@@ -262,15 +262,18 @@ function Handler:layout_real()
 
     for _, conn in ipairs(self.lookup:get_connections(source_id)) do
       local details = conn:details()
-      table.insert(children, {
+
+      ---@type Layout
+      local ly = {
         id = details.id,
         name = details.name,
-        type = "database",
+        type = "connection",
         -- set connection as active manually
         action_1 = function(cb)
           self:set_active(details.id)
           cb()
         end,
+        -- edit connection
         action_2 = function(cb)
           local original_details = conn:original_details()
           local prompt = {
@@ -295,20 +298,21 @@ function Handler:layout_real()
             end,
           })
         end,
-        -- remove connection (also trigger the source's function)
-        action_3 = function(cb)
-          vim.ui.input({ prompt = 'confirm deletion of "' .. details.name .. '"', default = "Y" }, function(input)
-            if not input or string.lower(input) ~= "y" then
-              return
-            end
+        pick_title = "Confirm Deletion",
+        pick_items = { "Yes", "No" },
+        -- remove connection
+        action_3 = function(cb, selection)
+          if selection == "Yes" then
             self:remove_connection(details.id)
-            cb()
-          end)
+          end
+          cb()
         end,
         children = function()
           return conn:layout()
         end,
-      })
+      }
+
+      table.insert(children, ly)
     end
 
     if #children > 0 then

--- a/lua/dbee/handler/init.lua
+++ b/lua/dbee/handler/init.lua
@@ -169,8 +169,6 @@ end
 function Handler:layout()
   -- in case there are no sources defined, return a helper layout
   if #self.lookup:get_sources() < 1 then
-    print("here")
-    vim.print(self:layout_help())
     return self:layout_help()
   end
   return self:layout_real()
@@ -292,7 +290,6 @@ function Handler:layout_real()
                 type = result.type,
                 page_size = tonumber(result["page size"]),
               }
-              -- parse page size to int
               pcall(self.add_connection, self, spec --[[@as connection_details]], source_id)
               cb()
             end,

--- a/lua/dbee/handler/lookup.lua
+++ b/lua/dbee/handler/lookup.lua
@@ -32,7 +32,6 @@ function Lookup:add_source(source)
   self.sources[id] = {
     source = source,
     connections = {},
-    active_connection = "",
   }
 end
 

--- a/lua/dbee/utils/init.lua
+++ b/lua/dbee/utils/init.lua
@@ -8,6 +8,8 @@ M.prompt = require("dbee.utils.prompt")
 
 M.once = require("dbee.utils.once")
 
+M.menu = require("dbee.utils.menu")
+
 -- Get random key from table
 ---@param tbl table key-value table
 ---@return any|nil key

--- a/lua/dbee/utils/init.lua
+++ b/lua/dbee/utils/init.lua
@@ -113,4 +113,16 @@ function M.sorted_keys(obj)
   return keys
 end
 
+-- Get number of parameters that a function takes
+---@param fun fun(...):any function to get the number of parameters of
+---@return integer # number of parameters
+function M.get_function_param_number(fun)
+  local info = debug.getinfo(fun)
+  if info == nil then
+    return 0
+  end
+
+  return info.nparams or 0
+end
+
 return M

--- a/lua/dbee/utils/menu.lua
+++ b/lua/dbee/utils/menu.lua
@@ -5,7 +5,8 @@ local M = {}
 ---@param winid integer window id
 ---@param items string[] items to select from
 ---@param on_select fun(item: string) selection callback
-function M.open(winid, items, on_select)
+---@param title string
+function M.open(winid, items, on_select, title)
   local width = vim.api.nvim_win_get_width(winid)
   local row, _ = unpack(vim.api.nvim_win_get_cursor(winid))
 
@@ -15,7 +16,7 @@ function M.open(winid, items, on_select)
       winid = winid,
     },
     position = {
-      row = row,
+      row = row + 1,
       col = 0,
     },
     size = {
@@ -23,6 +24,10 @@ function M.open(winid, items, on_select)
     },
     border = {
       style = { "─", "─", "─", "", "─", "─", "─", "" },
+      text = {
+        top = title,
+        top_align = "left",
+      },
     },
     win_options = {
       cursorline = true,

--- a/lua/dbee/utils/menu.lua
+++ b/lua/dbee/utils/menu.lua
@@ -1,0 +1,54 @@
+local Menu = require("nui.menu")
+
+local M = {}
+
+---@param winid integer window id
+---@param items string[] items to select from
+---@param on_select fun(item: string) selection callback
+function M.open(winid, items, on_select)
+  local width = vim.api.nvim_win_get_width(winid)
+  local row, _ = unpack(vim.api.nvim_win_get_cursor(winid))
+
+  local popup_options = {
+    relative = {
+      type = "win",
+      winid = winid,
+    },
+    position = {
+      row = row,
+      col = 0,
+    },
+    size = {
+      width = width,
+    },
+    border = {
+      style = { "─", "─", "─", "", "─", "─", "─", "" },
+    },
+    win_options = {
+      cursorline = true,
+    },
+  }
+
+  local lines = {}
+  for _, item in ipairs(items) do
+    table.insert(lines, Menu.item(item))
+  end
+
+  local menu = Menu(popup_options, {
+    lines = lines,
+    keymap = {
+      focus_next = { "j", "<Down>", "<Tab>" },
+      focus_prev = { "k", "<Up>", "<S-Tab>" },
+      close = { "<Esc>", "<C-c>", "q" },
+      submit = { "<CR>", "<Space>" },
+    },
+    on_close = function() end,
+    on_submit = function(item)
+      on_select(item.text)
+    end,
+  })
+
+  menu:mount()
+end
+
+return M

--- a/lua/dbee/utils/prompt.lua
+++ b/lua/dbee/utils/prompt.lua
@@ -144,8 +144,13 @@ function M.edit(file, opts)
   vim.api.nvim_create_autocmd({ "BufLeave", "BufWritePost" }, {
     buffer = bufnr,
     callback = function()
-      pcall(vim.api.nvim_win_close, winid, true)
-      pcall(vim.api.nvim_buf_delete, bufnr, {})
+      -- close the window if not using "wq" already
+      local cmd_hist = vim.api.nvim_exec2(":history cmd -1", { output = true })
+      local last_cmd = cmd_hist.output:gsub(".*\n>%s*%d+%s*(.*)%s*", "%1")
+      if not last_cmd:find("^wq") then
+        pcall(vim.api.nvim_win_close, winid, true)
+        pcall(vim.api.nvim_buf_delete, bufnr, {})
+      end
     end,
   })
 

--- a/plugin/nvim-dbee.vim
+++ b/plugin/nvim-dbee.vim
@@ -42,4 +42,5 @@ call remote#host#RegisterPlugin('nvim_dbee', '0', [
 \ {'type': 'function', 'name': 'Dbee_register_connection', 'sync': 1, 'opts': {}},
 \ {'type': 'function', 'name': 'Dbee_set_results_buf', 'sync': 1, 'opts': {}},
 \ {'type': 'function', 'name': 'Dbee_store', 'sync': 1, 'opts': {}},
+\ {'type': 'function', 'name': 'Dbee_switch_database', 'sync': 1, 'opts': {}},
 \ ])


### PR DESCRIPTION
This PR adds support for multiple databases on a single connection.
It also adds native pick list support in the drawer and makes the UI a bit nicer to use and doesn't rely on external plugins to make `vim.ui.select` look nice.

fixes #32 
addresses #15