### PR TITLE
feat: query cancellation

### DIFF
--- a/dbee/clients/bigquery.go
+++ b/dbee/clients/bigquery.go
@@ -111,14 +111,14 @@ func NewBigQuery(rawURL string) (*BigQueryClient, error) {
 	return client, nil
 }
 
-func (c *BigQueryClient) Query(queryStr string) (models.IterResult, error) {
+func (c *BigQueryClient) Query(ctx context.Context, queryStr string) (models.IterResult, error) {
 	query := c.c.Query(queryStr)
 	query.DisableQueryCache = c.disableQueryCache
 	query.MaxBytesBilled = c.maxBytesBilled
 	query.UseLegacySQL = c.useLegacySQL
 	query.Location = c.location
 
-	iter, err := query.Read(context.TODO())
+	iter, err := query.Read(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/dbee/clients/clients.go
+++ b/dbee/clients/clients.go
@@ -6,6 +6,8 @@ import (
 	"github.com/kndndrj/nvim-dbee/dbee/conn"
 )
 
+// creator is a function that creates a new client
+// based on the given url.
 type creator func(url string) (conn.Client, error)
 
 // storage holds implmented client types - specific clients register themselves in their init functions.
@@ -36,10 +38,10 @@ func (s *storage) Get(alias string) (creator, error) {
 }
 
 func NewFromType(url string, typ string) (conn.Client, error) {
-	new, err := Store.Get(typ)
+	newType, err := Store.Get(typ)
 	if err != nil {
 		return nil, err
 	}
 
-	return new(url)
+	return newType(url)
 }

--- a/dbee/clients/mongo.go
+++ b/dbee/clients/mongo.go
@@ -87,9 +87,7 @@ func (c *MongoClient) getCurrentDatabase(ctx context.Context) (string, error) {
 	return c.dbName, nil
 }
 
-func (c *MongoClient) Query(query string) (models.IterResult, error) {
-	ctx := context.Background()
-
+func (c *MongoClient) Query(ctx context.Context, query string) (models.IterResult, error) {
 	dbName, err := c.getCurrentDatabase(ctx)
 	if err != nil {
 		return nil, err

--- a/dbee/clients/mysql.go
+++ b/dbee/clients/mysql.go
@@ -1,6 +1,7 @@
 package clients
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"regexp"
@@ -44,8 +45,8 @@ func NewMysql(url string) (*MysqlClient, error) {
 	}, nil
 }
 
-func (c *MysqlClient) Query(query string) (models.IterResult, error) {
-	con, err := c.sql.Conn()
+func (c *MysqlClient) Query(ctx context.Context, query string) (models.IterResult, error) {
+	con, err := c.sql.NewConn(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +59,7 @@ func (c *MysqlClient) Query(query string) (models.IterResult, error) {
 		}
 	}()
 
-	rows, err := con.Query(query)
+	rows, err := con.Query(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -74,15 +75,16 @@ func (c *MysqlClient) Query(query string) (models.IterResult, error) {
 	rows.Close()
 
 	// empty header means no result -> get affected rows
-	rows, err = con.Query("select ROW_COUNT() as 'Rows Affected'")
+	rows, err = con.Query(ctx, "select ROW_COUNT() as 'Rows Affected'")
 	rows.SetCallback(cb)
 	return rows, err
 }
 
 func (c *MysqlClient) Layout() ([]models.Layout, error) {
 	query := `SELECT table_schema, table_name FROM information_schema.tables`
+	ctx := context.Background()
 
-	rows, err := c.Query(query)
+	rows, err := c.Query(ctx, query)
 	if err != nil {
 		return nil, err
 	}

--- a/dbee/clients/oracle.go
+++ b/dbee/clients/oracle.go
@@ -1,6 +1,7 @@
 package clients
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -34,8 +35,8 @@ func NewOracle(url string) (*OracleClient, error) {
 	}, nil
 }
 
-func (c *OracleClient) Query(query string) (models.IterResult, error) {
-	con, err := c.c.Conn()
+func (c *OracleClient) Query(ctx context.Context, query string) (models.IterResult, error) {
+	con, err := c.c.NewConn(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +56,7 @@ func (c *OracleClient) Query(query string) (models.IterResult, error) {
 	action := strings.ToLower(strings.Split(query, " ")[0])
 	hasReturnValues := strings.Contains(strings.ToLower(query), " returning ")
 	if (action == "update" || action == "delete" || action == "insert") && !hasReturnValues {
-		rows, err := con.Exec(query)
+		rows, err := con.Exec(ctx, query)
 		if err != nil {
 			return nil, err
 		}
@@ -63,7 +64,7 @@ func (c *OracleClient) Query(query string) (models.IterResult, error) {
 		return rows, nil
 	}
 
-	rows, err := con.Query(query)
+	rows, err := con.Query(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +94,8 @@ func (c *OracleClient) Layout() ([]models.Layout, error) {
 		ORDER BY T.table_name
 	`
 
-	rows, err := c.Query(query)
+	ctx := context.Background()
+	rows, err := c.Query(ctx, query)
 	if err != nil {
 		return nil, err
 	}

--- a/dbee/clients/postgres.go
+++ b/dbee/clients/postgres.go
@@ -1,6 +1,7 @@
 package clients
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	nurl "net/url"
@@ -43,8 +44,8 @@ func NewPostgres(url string) (*PostgresClient, error) {
 	}, nil
 }
 
-func (c *PostgresClient) Query(query string) (models.IterResult, error) {
-	con, err := c.c.Conn()
+func (c *PostgresClient) Query(ctx context.Context, query string) (models.IterResult, error) {
+	con, err := c.c.NewConn(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +62,7 @@ func (c *PostgresClient) Query(query string) (models.IterResult, error) {
 	hasReturnValues := strings.Contains(strings.ToLower(query), " returning ")
 
 	if (action == "update" || action == "delete" || action == "insert") && !hasReturnValues {
-		rows, err := con.Exec(query)
+		rows, err := con.Exec(ctx, query)
 		if err != nil {
 			return nil, err
 		}
@@ -69,7 +70,7 @@ func (c *PostgresClient) Query(query string) (models.IterResult, error) {
 		return rows, nil
 	}
 
-	rows, err := con.Query(query)
+	rows, err := con.Query(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +92,8 @@ func (c *PostgresClient) Layout() ([]models.Layout, error) {
 		SELECT schemaname, matviewname, 'VIEW' FROM pg_matviews;
 	`
 
-	rows, err := c.Query(query)
+	ctx := context.Background()
+	rows, err := c.Query(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +112,8 @@ func (c *PostgresClient) ListDatabases() (current string, available []string, er
 		AND datname != current_database();
 	`
 
-	rows, err := c.Query(query)
+	ctx := context.Background()
+	rows, err := c.Query(ctx, query)
 	if err != nil {
 		return "", nil, err
 	}

--- a/dbee/clients/redis.go
+++ b/dbee/clients/redis.go
@@ -44,7 +44,7 @@ func NewRedis(url string) (*RedisClient, error) {
 	}, nil
 }
 
-func (c *RedisClient) Query(query string) (models.IterResult, error) {
+func (c *RedisClient) Query(ctx context.Context, query string) (models.IterResult, error) {
 	cmd, err := parseRedisCmd(query)
 	if err != nil {
 		return nil, err

--- a/dbee/clients/redshift.go
+++ b/dbee/clients/redshift.go
@@ -1,6 +1,7 @@
 package clients
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"net/url"
@@ -44,8 +45,8 @@ func NewRedshift(rawURL string) (*RedshiftClient, error) {
 }
 
 // Query executes a query and returns the result as an IterResult.
-func (c *RedshiftClient) Query(query string) (models.IterResult, error) {
-	con, err := c.c.Conn()
+func (c *RedshiftClient) Query(ctx context.Context, query string) (models.IterResult, error) {
+	con, err := c.c.NewConn(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +59,7 @@ func (c *RedshiftClient) Query(query string) (models.IterResult, error) {
 		}
 	}()
 
-	rows, err := con.Query(query)
+	rows, err := con.Query(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +93,8 @@ func (c *RedshiftClient) Layout() ([]models.Layout, error) {
 					n.nspname NOT IN ('information_schema', 'pg_catalog');
 	`
 
-	rows, err := c.Query(query)
+	ctx := context.Background()
+	rows, err := c.Query(ctx, query)
 	if err != nil {
 		return nil, err
 	}

--- a/dbee/clients/sqlite.go
+++ b/dbee/clients/sqlite.go
@@ -3,6 +3,7 @@
 package clients
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 
@@ -35,8 +36,8 @@ func NewSqlite(url string) (*SqliteClient, error) {
 	}, nil
 }
 
-func (c *SqliteClient) Query(query string) (models.IterResult, error) {
-	con, err := c.c.Conn()
+func (c *SqliteClient) Query(ctx context.Context, query string) (models.IterResult, error) {
+	con, err := c.c.NewConn(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +50,7 @@ func (c *SqliteClient) Query(query string) (models.IterResult, error) {
 		}
 	}()
 
-	rows, err := con.Query(query)
+	rows, err := con.Query(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +66,7 @@ func (c *SqliteClient) Query(query string) (models.IterResult, error) {
 	rows.Close()
 
 	// empty header means no result -> get affected rows
-	rows, err = con.Query("select changes() as 'Rows Affected'")
+	rows, err = con.Query(ctx, "select changes() as 'Rows Affected'")
 	rows.SetCallback(cb)
 	return rows, err
 }
@@ -73,7 +74,8 @@ func (c *SqliteClient) Query(query string) (models.IterResult, error) {
 func (c *SqliteClient) Layout() ([]models.Layout, error) {
 	query := `SELECT name FROM sqlite_schema WHERE type ='table'`
 
-	rows, err := c.Query(query)
+	ctx := context.Background()
+	rows, err := c.Query(ctx, query)
 	if err != nil {
 		return nil, err
 	}

--- a/dbee/clients/sqlserver.go
+++ b/dbee/clients/sqlserver.go
@@ -1,6 +1,7 @@
 package clients
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	nurl "net/url"
@@ -42,8 +43,8 @@ func NewSQLServer(url string) (*SQLServerClient, error) {
 	}, nil
 }
 
-func (c *SQLServerClient) Query(query string) (models.IterResult, error) {
-	con, err := c.c.Conn()
+func (c *SQLServerClient) Query(ctx context.Context, query string) (models.IterResult, error) {
+	con, err := c.c.NewConn(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +57,7 @@ func (c *SQLServerClient) Query(query string) (models.IterResult, error) {
 		}
 	}()
 
-	rows, err := con.Query(query)
+	rows, err := con.Query(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +73,7 @@ func (c *SQLServerClient) Query(query string) (models.IterResult, error) {
 	rows.Close()
 
 	// empty header means no result -> get affected rows
-	rows, err = con.Query("select @@ROWCOUNT as 'Rows Affected'")
+	rows, err = con.Query(ctx, "select @@ROWCOUNT as 'Rows Affected'")
 	rows.SetCallback(cb)
 	return rows, err
 }
@@ -80,7 +81,8 @@ func (c *SQLServerClient) Query(query string) (models.IterResult, error) {
 func (c *SQLServerClient) Layout() ([]models.Layout, error) {
 	query := `SELECT table_schema, table_name FROM INFORMATION_SCHEMA.TABLES`
 
-	rows, err := c.Query(query)
+	ctx := context.Background()
+	rows, err := c.Query(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +139,8 @@ func (c *SQLServerClient) ListDatabases() (current string, available []string, e
 		WHERE name != DB_NAME();
 	`
 
-	rows, err := c.Query(query)
+	ctx := context.Background()
+	rows, err := c.Query(ctx, query)
 	if err != nil {
 		return "", nil, err
 	}

--- a/dbee/conn/conn.go
+++ b/dbee/conn/conn.go
@@ -1,18 +1,13 @@
 package conn
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/kndndrj/nvim-dbee/dbee/models"
 )
 
 type (
-	// Input requires implementaions to provide iterator from a
-	// given string input, which can be a query or some sort of id
-	Input interface {
-		Query(string) (models.IterResult, error)
-	}
-
 	// Output recieves a result and does whatever it wants with it
 	Output interface {
 		Write(result models.Result) error
@@ -21,13 +16,13 @@ type (
 	// History is required to act as an input, output and provide a List method
 	History interface {
 		Output
-		Input
+		Query(string) (models.IterResult, error)
 		Layout() ([]models.Layout, error)
 	}
 
 	// Client is a special kind of input with extra stuff
 	Client interface {
-		Input
+		Query(context.Context, string) (models.IterResult, error)
 		Close()
 		Layout() ([]models.Layout, error)
 	}
@@ -61,10 +56,10 @@ func New(driver Client, blockUntil int, history History, logger models.Logger) *
 	}
 }
 
-func (c *Conn) Execute(query string) error {
+func (c *Conn) Execute(ctx context.Context, query string) error {
 	c.log.Debug("executing query: \"" + query + "\"")
 
-	rows, err := c.driver.Query(query)
+	rows, err := c.driver.Query(ctx, query)
 	if err != nil {
 		return err
 	}

--- a/dbee/conn/conn.go
+++ b/dbee/conn/conn.go
@@ -61,13 +61,6 @@ func New(driver Client, blockUntil int, history History, logger models.Logger) *
 func (c *Conn) Execute(ctx context.Context, query string) error {
 	c.log.Debug("executing query: \"" + query + "\"")
 
-	// Check for cancellation before starting the query
-	select {
-	case <-ctx.Done():
-		return ctx.Err() // Canceled
-	default:
-	}
-
 	rows, err := c.driver.Query(ctx, query)
 	if err != nil {
 		return err
@@ -76,8 +69,8 @@ func (c *Conn) Execute(ctx context.Context, query string) error {
 	// Check for cancellation during query execution
 	select {
 	case <-ctx.Done():
-		// Cancel the query and return an error
-		rows.Close() // Close the result set
+		// Cancel the query and return the error
+		rows.Close()
 		return ctx.Err()
 	default:
 	}

--- a/lua/dbee.lua
+++ b/lua/dbee.lua
@@ -18,6 +18,7 @@ m.loaded = false
 ---@type Config
 m.config = {}
 
+---  lazy_setup is called to lazy setup the result/editor/drwaer ui.
 local function lazy_setup()
   -- add install binary to path
   vim.env.PATH = install.path() .. ":" .. vim.env.PATH
@@ -65,8 +66,11 @@ local function lazy_setup()
     fallback_page_size = m.config.page_size,
     progress = m.config.progress_bar,
   })
+  ---@type Result
   m.result = Result:new(result_ui, m.handler, m.config.result)
+  ---@type Editor
   m.editor = Editor:new(editor_ui, m.handler, m.config.editor)
+  ---@type Drawer
   m.drawer = Drawer:new(drawer_ui, m.handler, m.editor, m.config.drawer)
 
   m.handler:add_helpers(m.config.extra_helpers)
@@ -88,6 +92,8 @@ local function pcall_lazy_setup()
   return true
 end
 
+--- validate_config validates the config object
+-- to check if it has all the required fields and its types.
 ---@param opts Config
 local function validate_config(opts)
   vim.validate {
@@ -220,6 +226,14 @@ function M.execute(query)
     return
   end
   m.handler:current_connection():execute(query)
+end
+--
+---@param query string query to execute on currently selected connection
+function M.cancel(query)
+  if not pcall_lazy_setup() then
+    return
+  end
+  m.handler:current_connection():cancel(query)
 end
 
 ---@param format "csv"|"json" format of the output

--- a/lua/dbee/config.lua
+++ b/lua/dbee/config.lua
@@ -186,6 +186,8 @@ M.default = {
       run_selection = { key = "BB", mode = "v" },
       -- run the whole file on the active connection
       run_file = { key = "BB", mode = "n" },
+      -- cancel the current query
+      cancel_run = { key = "<C-c>", mode = "n" },
     },
   },
 

--- a/lua/dbee/handler/conn.lua
+++ b/lua/dbee/handler/conn.lua
@@ -125,11 +125,11 @@ function Conn:execute(query, cb)
   cb = cb or function() end
   self.on_exec()
 
-  local cancel = progress.display(self.ui:buffer(), self.progress_bar)
+  local cancel_fn = progress.display(self.ui:buffer(), self.progress_bar)
 
   local cb_id = tostring(math.random())
   callbacker.register(cb_id, function(stats)
-    cancel()
+    cancel_fn()
     self.stats = stats
     if stats.success then
       self:show_page(0)
@@ -141,6 +141,30 @@ function Conn:execute(query, cb)
   self.page_ammount = 0
 
   vim.fn.Dbee_execute(self.id, query, cb_id)
+end
+--
+---@param query string query to execute
+---@param cb? fun() callback to execute when finished
+function Conn:cancel(query, cb)
+  cb = cb or function() end
+  self.on_exec()
+
+  local cancel_fn = progress.display(self.ui:buffer(), self.progress_bar)
+
+  local cb_id = tostring(math.random())
+  callbacker.register(cb_id, function(stats)
+    cancel_fn()
+    self.stats = stats
+    if stats.success then
+      self:show_page(0)
+    end
+    cb()
+  end)
+
+  self.page_index = 0
+  self.page_ammount = 0
+
+  vim.fn.Dbee_cancel(self.id, query, cb_id)
 end
 
 ---@param history_id string history id

--- a/plugin/nvim-dbee.vim
+++ b/plugin/nvim-dbee.vim
@@ -43,4 +43,5 @@ call remote#host#RegisterPlugin('nvim_dbee', '0', [
 \ {'type': 'function', 'name': 'Dbee_set_results_buf', 'sync': 1, 'opts': {}},
 \ {'type': 'function', 'name': 'Dbee_store', 'sync': 1, 'opts': {}},
 \ {'type': 'function', 'name': 'Dbee_switch_database', 'sync': 1, 'opts': {}},
+\ {'type': 'function', 'name': 'Dbee_cancel', 'sync': 1, 'opts': {}},
 \ ])


### PR DESCRIPTION
Added `Dbee_cancel` function. This cancels the latest running query.

I'm opening this as draft, as I need to fix a bug of when you cancel the query you receive "bad connection" on the next query, but the 2nd attempt works.. 

Feel free to add any commits you see fit @kndndrj 

Also, perhaps it is worth refactoring the frontend Lua a bit? I kind of like the style vim-dadbod-ui has, e.g. on action "list" you insert it into the editor and execute it from there etc. Separate the ownership a bit on what the drawer/editor/result should do.

Additionally, if you've time - could you add a `CONTRIBUTING.md` file, where logic such as how to run this locally to see debugging messages etc, exists? 😄