### PR TITLE
feat: specify mapping options via setup()

### DIFF
--- a/lua/dbee/config.lua
+++ b/lua/dbee/config.lua
@@ -4,7 +4,7 @@ local spinners = require("dbee.progress").spinners
 local M = {}
 local m = {}
 
----@alias mapping {key: string, mode: string}
+---@alias mapping {key: string, mode: string, opts?: table<string, any>}
 ---@alias wincmd string|fun():integer
 
 ---@class UiConfig

--- a/lua/dbee/ui.lua
+++ b/lua/dbee/ui.lua
@@ -90,7 +90,12 @@ function Ui:configure_mappings()
 
   for _, m in ipairs(self.keymap) do
     if m.action and type(m.action) == "function" and m.mapping and m.mapping.key and m.mapping.mode then
-      vim.keymap.set(m.mapping.mode, m.mapping.key, m.action, map_options)
+      vim.keymap.set(
+        m.mapping.mode,
+        m.mapping.key,
+        m.action,
+        vim.tbl_extend("force", map_options, m.mapping.opts or {})
+      )
     end
   end
 


### PR DESCRIPTION
because I want to do (re: [my dots]):
```
require("dbee").setup {
    ...
    editor = {
      mappings = {
        run_selection = {
          key = "<C-M>",
          mode = "x",
          opts = {
            expr = true,
          },
        },
      },
    },
    ...
  }
```

[my dots]: https://github.com/willruggiano/neovim.drv/commit/e90a152ad718a0dba3ae5f91ac3041d28706819e#diff-42d858c727559e58e80bc82d25072d505512c4b3aac7ff422b674aebd1a0082aR8-R14