### PR TITLE
refactor: return empty Columns

### DIFF
--- a/dbee/core/connection.go
+++ b/dbee/core/connection.go
@@ -148,7 +148,7 @@ func (c *Connection) GetColumns(opts *TableOptions) ([]*Column, error) {
 		return nil, fmt.Errorf("c.driver.Columns: %w", err)
 	}
 	if len(cols) < 1 {
-		return nil, errors.New("no column names found for specified opts")
+		return []*Column{}, nil
 	}
 
 	return cols, nil

--- a/dbee/core/result.go
+++ b/dbee/core/result.go
@@ -139,10 +139,7 @@ func (cr *Result) getRows(from, to int) (rows []Row, rangeFrom int, rangeTo int,
 	defer cancel()
 
 	// Wait for drain, available index or timeout
-	for {
-		if cr.isDrained || (to >= 0 && to <= len(cr.rows)) {
-			break
-		}
+	for !cr.isDrained && (to < 0 || to > len(cr.rows)) {
 
 		if err := ctx.Err(); err != nil {
 			return nil, 0, 0, fmt.Errorf("cache flushing timeout exceeded: %s", err)


### PR DESCRIPTION
nit improvement to return empty columns for the cmp instead of error. Mainly because returning error results in neovim error and not "silencing" it. Just a bit smoother experience 😋 

The other refactoring just nice to have from the linter haha