### PR TITLE
Fix: `ResultStream` iterator throws error when BigQuery iterator returns `iterator.Done` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,8 +246,8 @@ Here are a few steps to quickly get started:
   already be present. If there are more than `page_size` results, you can "page"
   thrugh them using one of the following:
 
-  - Using `require("dbee")api.ui.result_page_next()` and
-    `require("dbee")api.ui.result_page_prev()` from anywhere (even if your
+  - Using `require("dbee").api.ui.result_page_next()` and
+    `require("dbee").api.ui.result_page_prev()` from anywhere (even if your
     cursor is outside the result buffer).
   - Using `L` for next and `H` for previous page if the cursor is located inside
     the results buffer.

--- a/README.md
+++ b/README.md
@@ -244,13 +244,15 @@ Here are a few steps to quickly get started:
   buffer (bottom right by default). If the total number of results was lower
   than the `page_size` parameter in config (100 by default), all results should
   already be present. If there are more than `page_size` results, you can "page"
-  thrugh them using one of the following:
+  through them using one of the following:
 
-  - Using `require("dbee").api.ui.result_page_next()` and
-    `require("dbee").api.ui.result_page_prev()` from anywhere (even if your
-    cursor is outside the result buffer).
-  - Using `L` for next and `H` for previous page if the cursor is located inside
-    the results buffer.
+| Navigation using lua script <br/> (even if your cursor is outside the result buffer) | Description | Default key mapping <br/> (cursor should be inside result buffer) |
+|---|:---:|:---:|
+| `require("dbee").api.ui.result_page_next()` | Go to next page | L |
+| `require("dbee").api.ui.result_page_prev()` | Go to the previous page | H |
+| `require("dbee").api.ui.result_page_last()` | Go to the last page | E |
+| `require("dbee").api.ui.result_page_first()` | Go to the first page | F |
+
 
 - Once in the "result" buffer, you can yank the results with the following keys:
 

--- a/doc/dbee-reference.txt
+++ b/doc/dbee-reference.txt
@@ -855,6 +855,12 @@ ui.result_page_next()                                      *ui.result_page_next*
 ui.result_page_prev()                                      *ui.result_page_prev*
      Go to previous page in results UI and display it.
 
+ui.result_page_last()                                      *ui.result_page_last*
+     Go to lastious page in results UI and display it.
+
+ui.result_page_first()                                      *ui.result_page_first*
+     Go to firstious page in results UI and display it.
+
 
 ui.result_show({winid})                                         *ui.result_show*
      Open the result UI.

--- a/doc/dbee.txt
+++ b/doc/dbee.txt
@@ -281,6 +281,8 @@ Here are the defaults:
           -- next/previous page
           { key = "L", mode = "", action = "page_next" },
           { key = "H", mode = "", action = "page_prev" },
+          { key = "E", mode = "", action = "page_last" },
+          { key = "F", mode = "", action = "page_first" },
           -- yank rows as csv/json
           { key = "yaj", mode = "n", action = "yank_current_json" },
           { key = "yaj", mode = "v", action = "yank_selection_json" },

--- a/lua/dbee/api/ui.lua
+++ b/lua/dbee/api/ui.lua
@@ -160,6 +160,16 @@ function ui.result_page_prev()
   entry.get_ui().result:page_prev()
 end
 
+--- Go to last page in results UI and display it.
+function ui.result_page_last()
+  entry.get_ui().result:page_last()
+end
+
+--- Go to first page in results UI and display it.
+function ui.result_page_first()
+  entry.get_ui().result:page_first()
+end
+
 --- Open the result UI.
 ---@param winid integer
 function ui.result_show(winid)

--- a/lua/dbee/config.lua
+++ b/lua/dbee/config.lua
@@ -191,6 +191,8 @@ config.default = {
       -- next/previous page
       { key = "L", mode = "", action = "page_next" },
       { key = "H", mode = "", action = "page_prev" },
+      { key = "E", mode = "", action = "page_last" },
+      { key = "F", mode = "", action = "page_first" },
       -- yank rows as csv/json
       { key = "yaj", mode = "n", action = "yank_current_json" },
       { key = "yaj", mode = "v", action = "yank_selection_json" },

--- a/lua/dbee/ui/result/init.lua
+++ b/lua/dbee/ui/result/init.lua
@@ -206,6 +206,12 @@ function ResultTile:get_actions()
     page_prev = function()
       self:page_prev()
     end,
+    page_last = function()
+      self:page_last()
+    end,
+    page_first = function()
+      self:page_first()
+    end,
 
     -- yank functions
     yank_current_json = function()
@@ -261,6 +267,15 @@ end
 
 function ResultTile:page_prev()
   self.page_index = self:display_result(self.page_index - 1)
+end
+
+
+function ResultTile:page_last()
+  self.page_index = self:display_result(self.page_ammount)
+end
+
+function ResultTile:page_first()
+  self.page_index = self:display_result(0)
 end
 
 -- wrapper for storing the current row


### PR DESCRIPTION
This pull request:

* Fixes: https://github.com/kndndrj/nvim-dbee/issues/67
* README fix for next and previous result page 

BigQuery iterator when has no items left, throws `iterator.Done` which when handled appropriately solves this issue.  Please see screenshot attached.

Please let me know if this is not the right way to fix this as I had not written any Go before, but it works :)

**Testing** 
*  **BigQuery**: Is able to fetch results for tables with over 150k rows
 * **Other dBs**: To make sure other database drivers are not affected by this. I tested the code on a local sqlite dB which worked without any issues.

![CleanShot 2024-01-13 at 12 44 23@2x](https://github.com/kndndrj/nvim-dbee/assets/34306898/bdece69b-4f18-4912-a284-35784cd8d28c)

