### PR TITLE
Feat: show total number of rows returned by the query

### DIFF
--- a/lua/dbee/ui/result/init.lua
+++ b/lua/dbee/ui/result/init.lua
@@ -185,7 +185,7 @@ function ResultTile:display_result(page)
     vim.api.nvim_win_set_option(
       self.winid,
       "winbar",
-      string.format("%d/%d%%=Took %.3fs", page + 1, self.page_ammount + 1, seconds)
+      string.format("%d/%d (%d)%%=Took %.3fs", page + 1, self.page_ammount + 1, length, seconds)
     )
   end
 


### PR DESCRIPTION
This merge request:

Shows number of rows returned by the query. I find this feature very useful instead of going manually to the last page or writing a separate query using COUNT(*) to see how many rows does the query returns.

![CleanShot 2024-01-15 at 18 13 01@2x](https://github.com/kndndrj/nvim-dbee/assets/34306898/32b99ce7-2a87-4c07-be3a-0e08fa2e613e)
