### PR TITLE
fix/docs-remove-duplicate-tags

### DIFF
--- a/doc/dbee-reference.txt
+++ b/doc/dbee-reference.txt
@@ -452,9 +452,6 @@ layouts.Default:new({opts?})                               *layouts.Default:new*
         (DefaultLayout)
 
 
-DefaultLayout                                                    *DefaultLayout*
-
-
 ==============================================================================
 Dbee Core API                                                *dbee.ref.api.core*
 

--- a/lua/dbee/layouts/init.lua
+++ b/lua/dbee/layouts/init.lua
@@ -45,7 +45,6 @@ function layouts.Default:new(opts)
     end
   end
 
-  ---@class DefaultLayout
   local o = {
     egg = nil,
     windows = {},


### PR DESCRIPTION
This PR removes duplicate definition of `DefaultLayout` in docs

Fixes #72

EDIT:
#73 could be closed as well