### PR TITLE
feat: add reload_sources method

### DIFF
--- a/lua/dbee.lua
+++ b/lua/dbee.lua
@@ -40,6 +40,11 @@ function dbee.is_open()
   return entry.is_ui_open()
 end
 
+--- Reload all registered sources.
+function dbee.reload_sources()
+  entry.get_handler():reload_sources()
+end
+
 ---Check if dbee core has been loaded.
 ---@return boolean
 function dbee.is_core_loaded()

--- a/lua/dbee/api/core.lua
+++ b/lua/dbee/api/core.lua
@@ -37,6 +37,11 @@ function core.source_reload(id)
   entry.get_handler():source_reload(id)
 end
 
+---Reload all sources.
+function core.reload_sources()
+  entry.get_handler():reload_sources()
+end
+
 ---Add connections to the source.
 ---@param id source_id
 ---@param details ConnectionParams[]

--- a/lua/dbee/handler/init.lua
+++ b/lua/dbee/handler/init.lua
@@ -73,6 +73,14 @@ function Handler:source_reload(id)
   end
 end
 
+--- reload all sources via calling `source_reload`
+--- on each registered source.
+function Handler:reload_sources()
+  for id, _ in pairs(self.sources) do
+    self:source_reload(id)
+  end
+end
+
 ---@param id source_id
 ---@param details ConnectionParams[]
 function Handler:source_add_connections(id, details)


### PR DESCRIPTION
New feature allowing user to reload the connections/sources on demand.

The current scenario/setup I've is that when I start dbee for the first time, I run a bash script which fetches temporary credentials to my database and sets that in a `connections.json` file. When the credentials expires you can just source the same bash script again and ergo update the `connections.json` file.

However, depending on the "database user" (e.g. analyst/developer/admin), this doesn't work. So, I would have to refresh my source connection again by just reloading it.

Let me know if you don't think this is a method you want to open up to core entry `require("dbee").reload_sources()` and instead point them to use the `core` api export. 