### PR TITLE
feat!: move database list from xdg cache to state

### DIFF
--- a/lua/dbee/config.lua
+++ b/lua/dbee/config.lua
@@ -48,7 +48,7 @@ config.default = {
   -- loads connections from files and environment variables
   sources = {
     require("dbee.sources").EnvSource:new("DBEE_CONNECTIONS"),
-    require("dbee.sources").FileSource:new(vim.fn.stdpath("cache") .. "/dbee/persistence.json"),
+    require("dbee.sources").FileSource:new(vim.fn.stdpath("state") .. "/dbee/persistence.json"),
   },
   -- extra table helpers per connection type
   -- every helper value is a go-template with values set for


### PR DESCRIPTION
The connection configuration is part of the configuration, it shouldn't be wiped along with the cache.
One should be able to  wipe ~/.cache  without annoyance but this makes it harder.

There is now the problem of migrating the file that should be conveyed to the user, maybe via a "breaking changes" issue.