### PR TITLE
fix(mysql): handle schema in default helpers

### DIFF
--- a/dbee/adapters/mysql.go
+++ b/dbee/adapters/mysql.go
@@ -42,10 +42,15 @@ func (m *MySQL) Connect(url string) (core.Driver, error) {
 }
 
 func (*MySQL) GetHelpers(opts *core.TableOptions) map[string]string {
+	tableRef := fmt.Sprintf("`%s`", opts.Table)
+	if opts.Schema != "" {
+		tableRef = fmt.Sprintf("`%s`.`%s`", opts.Schema, opts.Table)
+	}
+
 	return map[string]string{
-		"List":         fmt.Sprintf("SELECT * FROM `%s` LIMIT 500", opts.Table),
-		"Columns":      fmt.Sprintf("DESCRIBE `%s`", opts.Table),
-		"Indexes":      fmt.Sprintf("SHOW INDEXES FROM `%s`", opts.Table),
+		"List":         fmt.Sprintf("SELECT * FROM %s LIMIT 500", tableRef),
+		"Columns":      fmt.Sprintf("DESCRIBE %s", tableRef),
+		"Indexes":      fmt.Sprintf("SHOW INDEXES FROM %s", tableRef),
 		"Foreign Keys": fmt.Sprintf("SELECT * FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s' AND CONSTRAINT_TYPE = 'FOREIGN KEY'", opts.Schema, opts.Table),
 		"Primary Keys": fmt.Sprintf("SELECT * FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s' AND CONSTRAINT_TYPE = 'PRIMARY KEY'", opts.Schema, opts.Table),
 	}


### PR DESCRIPTION
First time coding in GO, so this is more of a suggetion than a proper PR.

From what I understand the Mysql-driver does not support "database-switching", 
When I connect to a mysql-server without providing a default schema eg. "usrname:password@tcp(localhost:3306)/", I cannot use any helpers, nor expand any tables in the drawer.

With this change, I can now use default helpers in any schema/table, 

It seems to expanding of tables in the drawer is more complex, maybe someone could point me in the right direction to implement this?






