### PR TITLE
feat: add current_database_changed event bus

### DIFF
--- a/dbee/handler/event_bus.go
+++ b/dbee/handler/event_bus.go
@@ -54,12 +54,13 @@ func (eb *eventBus) CurrentConnectionChanged(id core.ConnectionID) {
 	eb.callLua("current_connection_changed", data)
 }
 
-// CurrentDatabaseChanged is called when the current database is changed.
-// Sends the new database name to the Lua event handler.
-func (eb *eventBus) CurrentDatabaseChanged(name string) {
+// DatabaseSelected is called when the selected database of a connection is changed.
+// Sends the new database name along with affected connection ID to the lua event handler.
+func (eb *eventBus) DatabaseSelected(id core.ConnectionID, dbname string) {
 	data := fmt.Sprintf(`{
-		db_name = %q,
-	}`, name)
+		conn_id = %q,
+		database_name = %q,
+	}`, id, dbname)
 
-	eb.callLua("current_database_changed", data)
+	eb.callLua("database_selected", data)
 }

--- a/dbee/handler/event_bus.go
+++ b/dbee/handler/event_bus.go
@@ -53,3 +53,13 @@ func (eb *eventBus) CurrentConnectionChanged(id core.ConnectionID) {
 
 	eb.callLua("current_connection_changed", data)
 }
+
+// CurrentDatabaseChanged is called when the current database is changed.
+// Sends the new database name to the Lua event handler.
+func (eb *eventBus) CurrentDatabaseChanged(name string) {
+	data := fmt.Sprintf(`{
+		db_name = %q,
+	}`, name)
+
+	eb.callLua("current_database_changed", data)
+}

--- a/dbee/handler/handler.go
+++ b/dbee/handler/handler.go
@@ -257,6 +257,7 @@ func (h *Handler) ConnectionSelectDatabase(connID core.ConnectionID, database st
 	if err != nil {
 		return fmt.Errorf("c.SelectDatabase: %w", err)
 	}
+	h.events.CurrentDatabaseChanged(database)
 
 	return nil
 }

--- a/dbee/handler/handler.go
+++ b/dbee/handler/handler.go
@@ -257,7 +257,7 @@ func (h *Handler) ConnectionSelectDatabase(connID core.ConnectionID, database st
 	if err != nil {
 		return fmt.Errorf("c.SelectDatabase: %w", err)
 	}
-	h.events.CurrentDatabaseChanged(database)
+	h.events.DatabaseSelected(connID, database)
 
 	return nil
 }

--- a/lua/dbee/doc.lua
+++ b/lua/dbee/doc.lua
@@ -104,6 +104,7 @@
 ---@alias core_event_name
 ---| '"call_state_changed"'
 ---| '"current_connection_changed"'
+---| '"current_database_changed"'
 
 ---Available editor events.
 ---@alias editor_event_name

--- a/lua/dbee/doc.lua
+++ b/lua/dbee/doc.lua
@@ -104,7 +104,7 @@
 ---@alias core_event_name
 ---| '"call_state_changed"'
 ---| '"current_connection_changed"'
----| '"current_database_changed"'
+---| '"database_selected"'
 
 ---Available editor events.
 ---@alias editor_event_name


### PR DESCRIPTION
New feature which allows exposure of events if the database has changed.

This is useful for cmp-dbee to request a new "structure" of the database even if the connection stays the same.

I wanted to add this to e.g. "current_connection_change" but since some adapters don't have the concept of "databases" I decided to add a new one to have clean separation.