### PR TITLE
Update DrawerUI Helper to use a GUID instead of `os.clock()` 

### DIFF
--- a/lua/dbee/ui/drawer/convert.lua
+++ b/lua/dbee/ui/drawer/convert.lua
@@ -316,7 +316,7 @@ function M.help_node(mappings)
       table.insert(
         children,
         NuiTree.Node {
-          id = "__help_action_" .. tostring(os.clock()),
+          id = "__help_action_" .. utils.generate_guid(7),
           name = km.action .. " = " .. km.key .. " (" .. km.mode .. ")",
           type = "",
         }

--- a/lua/dbee/utils.lua
+++ b/lua/dbee/utils.lua
@@ -142,4 +142,18 @@ function M.create_singleton_autocmd(events, opts)
   vim.api.nvim_create_autocmd(events, opts)
 end
 
+-- Creates a GUID based of the character length passed
+---@param length integer length of the GUID generated
+---@return string A generated guid
+function M.generate_guid(length)
+  local template = string.rep('x', length)
+
+  local guid = string.gsub(template, 'x', function()
+    local v = math.random(0,15)
+    return string.format('%x', v)
+  end)
+
+  return guid
+end
+
 return M


### PR DESCRIPTION
This addresses: #92

Which corrects the `DrawerUI` from erroring on windows when running `Dbee open` or `require('dbee').open()`. 

`generate_guid` creates a unique guid that gets assigned to the `node_id`