### PR TITLE
fix: duplicate "DefaultLayout" Tag in reference doc

### DIFF
--- a/doc/dbee-reference.txt
+++ b/doc/dbee-reference.txt
@@ -452,9 +452,6 @@ layouts.Default:new({opts?})                               *layouts.Default:new*
         (DefaultLayout)
 
 
-DefaultLayout                                                    *DefaultLayout*
-
-
 ==============================================================================
 Dbee Core API                                                *dbee.ref.api.core*
 

--- a/lua/dbee/layouts/init.lua
+++ b/lua/dbee/layouts/init.lua
@@ -45,7 +45,6 @@ function layouts.Default:new(opts)
     end
   end
 
-  ---@class DefaultLayout
   local o = {
     egg = nil,
     windows = {},


### PR DESCRIPTION
## Describe your changes

Remove the duplacated "DefaultLayout" definition and regenerate the reference document.

## Issue ticket number and link

https://github.com/kndndrj/nvim-dbee/issues/72
