### PR TITLE
fix: sort help functions by action name

### DIFF
--- a/lua/dbee/ui/drawer/convert.lua
+++ b/lua/dbee/ui/drawer/convert.lua
@@ -335,7 +335,7 @@ function M.help_node(mappings)
   end
 
   table.sort(children, function(k1, k2)
-    return k1.id < k2.id
+    return k1.name < k2.name
   end)
 
   local node = NuiTree.Node({


### PR DESCRIPTION
This is just a small thing, but it kinda annoyed me. 🙃 
The help functions in the left side menu was ordered in different ways every time it was opened so I changed the sorting to sort by name instead of id to get a consistent sorting.

I hope it's okay that I created a PR for this.