### PR TITLE
fix: Add version check for buffer option

### DIFF
--- a/lua/dbee/ui/drawer/convert.lua
+++ b/lua/dbee/ui/drawer/convert.lua
@@ -360,7 +360,13 @@ local function modified_suffix(bufnr, refresh)
   end
 
   local suffix = ""
-  if vim.api.nvim_buf_get_option(bufnr, "modified") then
+  local modified
+  if vim.fn.has('nvim-0.10') == 1 then
+    modified = vim.api.nvim_get_option_value("modified", {buf = bufnr})
+  else
+    modified = vim.api.nvim_buf_get_option(bufnr, "modified")
+  end
+  if modified then
     suffix = " ●"
   end
 


### PR DESCRIPTION
The`nvim_buf_get_option` is depricated from `nvim-0.10`: https://neovim.io/doc/user/deprecated.html#nvim_buf_get_option()

This simply re-enables the little "dot" that indicates if a buffer is modified, using a backwards compatible check.