### PR TITLE
Add database switching for mysql connections

### DIFF
--- a/dbee/adapters/mysql.go
+++ b/dbee/adapters/mysql.go
@@ -3,9 +3,8 @@ package adapters
 import (
 	"database/sql"
 	"fmt"
-	"regexp"
 
-	_ "github.com/go-sql-driver/mysql"
+	"github.com/go-sql-driver/mysql" // Import normally to access mysql.ParseDSN
 
 	"github.com/kndndrj/nvim-dbee/dbee/core"
 	"github.com/kndndrj/nvim-dbee/dbee/core/builders"
@@ -21,31 +20,31 @@ var _ core.Adapter = (*MySQL)(nil)
 type MySQL struct{}
 
 func (m *MySQL) Connect(url string) (core.Driver, error) {
-	// add multiple statements support parameter
-	match, err := regexp.MatchString(`[\?][\w]+=[\w-]+`, url)
+	// parse the connection string into a mysql.Config struct
+	cfg, err := mysql.ParseDSN(url)
 	if err != nil {
-		return nil, err
-	}
-	sep := "?"
-	if match {
-		sep = "&"
+		return nil, fmt.Errorf("could not parse db connection string: %w", err)
 	}
 
-	db, err := sql.Open("mysql", url+sep+"multiStatements=true")
+	// add multiple statements support parameter
+	cfg.MultiStatements = true
+
+	db, err := sql.Open("mysql", cfg.FormatDSN())
 	if err != nil {
 		return nil, fmt.Errorf("unable to connect to mysql database: %v", err)
 	}
 
 	return &mySQLDriver{
-		c: builders.NewClient(db),
+		c:   builders.NewClient(db),
+		cfg: cfg,
 	}, nil
 }
 
 func (*MySQL) GetHelpers(opts *core.TableOptions) map[string]string {
 	return map[string]string{
-		"List":         fmt.Sprintf("SELECT * FROM `%s` LIMIT 500", opts.Table),
-		"Columns":      fmt.Sprintf("DESCRIBE `%s`", opts.Table),
-		"Indexes":      fmt.Sprintf("SHOW INDEXES FROM `%s`", opts.Table),
+		"List":         fmt.Sprintf("SELECT * FROM `%s`.`%s` LIMIT 500", opts.Schema, opts.Table),
+		"Columns":      fmt.Sprintf("DESCRIBE `%s`.`%s`", opts.Schema, opts.Table),
+		"Indexes":      fmt.Sprintf("SHOW INDEXES FROM `%s`.`%s`", opts.Schema, opts.Table),
 		"Foreign Keys": fmt.Sprintf("SELECT * FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s' AND CONSTRAINT_TYPE = 'FOREIGN KEY'", opts.Schema, opts.Table),
 		"Primary Keys": fmt.Sprintf("SELECT * FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s' AND CONSTRAINT_TYPE = 'PRIMARY KEY'", opts.Schema, opts.Table),
 	}

--- a/dbee/adapters/mysql_driver.go
+++ b/dbee/adapters/mysql_driver.go
@@ -2,15 +2,22 @@ package adapters
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
 
+	"github.com/go-sql-driver/mysql"
 	"github.com/kndndrj/nvim-dbee/dbee/core"
 	"github.com/kndndrj/nvim-dbee/dbee/core/builders"
 )
 
-var _ core.Driver = (*mySQLDriver)(nil)
+var (
+	_ core.Driver           = (*mySQLDriver)(nil)
+	_ core.DatabaseSwitcher = (*mySQLDriver)(nil)
+)
 
 type mySQLDriver struct {
-	c *builders.Client
+	c   *builders.Client
+	cfg *mysql.Config
 }
 
 func (c *mySQLDriver) Query(ctx context.Context, query string) (core.ResultStream, error) {
@@ -18,8 +25,46 @@ func (c *mySQLDriver) Query(ctx context.Context, query string) (core.ResultStrea
 	return c.c.QueryUntilNotEmpty(ctx, query, "select ROW_COUNT() as 'Rows Affected'")
 }
 
+func (c *mySQLDriver) ListDatabases() (current string, available []string, err error) {
+	query := `
+		SELECT IFNULL(DATABASE(), 'mysql') as current_database, SCHEMA_NAME as available_databases
+    FROM information_schema.SCHEMATA
+    WHERE SCHEMA_NAME <> IFNULL(DATABASE(), '');
+	`
+
+	rows, err := c.Query(context.TODO(), query)
+	if err != nil {
+		return "", nil, err
+	}
+
+	for rows.HasNext() {
+		row, err := rows.Next()
+		if err != nil {
+			return "", nil, err
+		}
+
+		// We know for a fact there are 2 string fields (see query above)
+		current = row[0].(string)
+		available = append(available, row[1].(string))
+	}
+
+	return current, available, nil
+}
+
+func (c *mySQLDriver) SelectDatabase(name string) error {
+	c.cfg.DBName = name
+	db, err := sql.Open("mysql", c.cfg.FormatDSN())
+	if err != nil {
+		return fmt.Errorf("unable to switch databases: %w", err)
+	}
+
+	c.c.Swap(db)
+
+	return nil
+}
+
 func (c *mySQLDriver) Columns(opts *core.TableOptions) ([]*core.Column, error) {
-	return c.c.ColumnsFromQuery("DESCRIBE `%s`", opts.Table)
+	return c.c.ColumnsFromQuery("DESCRIBE `%s`.`%s`", opts.Schema, opts.Table)
 }
 
 func (c *mySQLDriver) Structure() ([]*core.Structure, error) {


### PR DESCRIPTION
It exists in other connections, and it is possible in MySql.

This will solve the errors when using MySQL connection and expanding some tables inside another (non-default) schema in the connections tree. 
Currently, it is only possible for the schema name set in the connection url.

In addition, I modified the URL regex/concatenation logic used for MySQL connection to use `cfg = ParseDSN(url) / url = cfg.FormatDSN()`
 which should improve characters escaping for passwords in the connection URL.
