### PR TITLE
Update the MySQL connection url to the format supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ The above sources are just built-ins. Here is a short description of them:
     export DBEE_CONNECTIONS='[
         {
             "name": "DB from env",
-            "url": "mysql://...",
+            "url": "username:password@tcp(host)/database-name",
             "type": "mysql"
         }
     ]'


### PR DESCRIPTION
The `mysql://` component causes connection errors as it tries to connect with the username `mysql`. Also the `tcp(...)` component is probably what most people will want, so best to have it in the documented example.