### PR TITLE
ci: fix artifacts workflow and update trigger events

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -3,6 +3,7 @@ name: Compile and Upload Binaries
 on:
   release:
     types: [published]
+  workflow_dispatch: # manual trigger for full matrix
   pull_request:
     branches: [master]
   push:
@@ -22,7 +23,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Create Matrix
         id: set-matrix
-        run: ./ci/target-matrix.sh >> "$GITHUB_OUTPUT"
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            ./ci/target-matrix.sh --primary >> "$GITHUB_OUTPUT"
+          else
+            ./ci/target-matrix.sh >> "$GITHUB_OUTPUT"
+          fi
 
   go-build:
     needs: [assemble-os-matrix]

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -3,13 +3,10 @@ name: Compile and Upload Binaries
 on:
   release:
     types: [published]
+  pull_request:
+    branches: [master]
   push:
-    tags-ignore:
-      # ignore all pushed tags
-      - "**"
-    branches:
-      # run for all branches
-      - "**"
+    branches: [master]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -80,7 +80,7 @@ jobs:
           echo "${{ matrix.goarch }}" > ci_tmp/meta/arch
       - name: Upload metadata
         if: github.event_name == 'release'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.goos }}_${{ matrix.goarch }}
           path: ci_tmp/meta/*
@@ -95,7 +95,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Get metadata
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: meta
       - name: Create Install File from metadata

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -1,13 +1,14 @@
 name: Documentation Generation
 
 on:
+  pull_request:
+    branches: [master]
   push:
-    tags-ignore:
-      # ignore all tags
-      - '**'
-    branches:
-      # run for all branches
-      - '**'
+    branches: [master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   readme-docs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,13 +1,14 @@
 name: Linting and Style Checking
 
 on:
+  pull_request:
+    branches: [master]
   push:
-    tags-ignore:
-      # ignore all tags
-      - '**'
-    branches:
-      # run for all branches
-      - '**'
+    branches: [master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   luacheck:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Lua Style Check
-        uses: JohnnyMorganz/stylua-action@v3
+        uses: JohnnyMorganz/stylua-action@v4
         with:
           version: v0.17
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -38,9 +38,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Python Setup
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: "3.10"
       - name: Install mdformat
         run: |
           pip install mdformat-gfm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,11 +4,7 @@ on:
   workflow_dispatch: # allow manual invocation of this workflow (e.g. integration tests)
   pull_request:
   push:
-    tags-ignore:
-      # ignore all tags
-      - "**"
-    branches:
-      - master
+    branches: [master]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}

--- a/ci/target-matrix.sh
+++ b/ci/target-matrix.sh
@@ -3,8 +3,17 @@
 
 default_buildplatform="ubuntu-latest"
 
+# handle primary platforms flag (used in pull_request CI/CD)
+if [ "$1" = "--primary" ]; then
+    primary_filter='[.[] | select(.primary == true)]'
+else
+    primary_filter='.'
+fi
 # strip comments
 targets="$(sed '/^\s*\/\//d;s/\/\/.*//' "$(dirname "$0")/targets.json")"
+
+# filter for primary platforms if requested
+targets="$(echo "$targets" | jq "$primary_filter")"
 
 # assign a default buildplatform
 targets="$(echo "$targets" | jq 'map(

--- a/ci/targets.json
+++ b/ci/targets.json
@@ -9,212 +9,218 @@
 //     "cgo" - is cgo enabled or not
 //
 [
-    //
-    // 1st class support. We strive to provide best support for these platforms.
-    //
-    {
-        "goos": "darwin",
-        "goarch": "amd64",
-        "buildplatform": "macos-13",
-        "cgo": true
-    },
-    {
-        "goos": "darwin",
-        "goarch": "arm64",
-        "buildplatform": "macos-13",
-        "cgo": true
-    },
-    {
-        "goos": "linux",
-        "goarch": "amd64",
-        "crossarch": "x86_64-linux",
-        "buildtags": "duckdb_from_source"
-    },
-    {
-        "goos": "linux",
-        "goarch": "arm64",
-        "crossarch": "aarch64-linux"
-    },
-    {
-        "goos": "windows",
-        "goarch": "amd64",
-        "buildplatform": "windows-latest",
-        "cgo": true
-    },
-    {
-        "goos": "windows",
-        "goarch": "arm64",
-        "crossarch": "aarch64-windows",
-        "buildplatform": "windows-latest",
-        "cgo": true
-    },
-    {
-        "goos": "android",
-        "goarch": "arm64"
-    },
-    {
-        "goos": "dragonfly",
-        "goarch": "amd64"
-    },
-    {
-        "goos": "freebsd",
-        "goarch": "386"
-    },
-    {
-        "goos": "freebsd",
-        "goarch": "amd64"
-    },
-    {
-        "goos": "freebsd",
-        "goarch": "arm"
-    },
-    {
-        "goos": "freebsd",
-        "goarch": "arm64"
-    },
-    {
-        "goos": "freebsd",
-        "goarch": "riscv64"
-    },
-    {
-        "goos": "illumos",
-        "goarch": "amd64"
-    },
-    {
-        "goos": "linux",
-        "goarch": "386"
-    },
-    {
-        "goos": "linux",
-        "goarch": "arm"
-    },
-    {
-        "goos": "linux",
-        "goarch": "loong64"
-    },
-    {
-        "goos": "linux",
-        "goarch": "mips64"
-    },
-    {
-        "goos": "linux",
-        "goarch": "mips64le"
-    },
-    {
-        "goos": "linux",
-        "goarch": "ppc64"
-    },
-    {
-        "goos": "linux",
-        "goarch": "ppc64le"
-    },
-    {
-        "goos": "linux",
-        "goarch": "riscv64",
-        "crossarch": "riscv64-linux"
-    },
-    {
-        "goos": "linux",
-        "goarch": "s390x"
-    },
-    {
-        "goos": "netbsd",
-        "goarch": "386"
-    },
-    {
-        "goos": "netbsd",
-        "goarch": "amd64"
-    },
-    {
-        "goos": "netbsd",
-        "goarch": "arm"
-    },
-    {
-        "goos": "netbsd",
-        "goarch": "arm64"
-    },
-    {
-        "goos": "openbsd",
-        "goarch": "386"
-    },
-    {
-        "goos": "openbsd",
-        "goarch": "amd64"
-    },
-    {
-        "goos": "openbsd",
-        "goarch": "arm"
-    },
-    {
-        "goos": "openbsd",
-        "goarch": "arm64"
-    },
-    {
-        "goos": "solaris",
-        "goarch": "amd64"
-    },
-    {
-        "goos": "windows",
-        "goarch": "386",
-        "crossarch": "x86-windows",
-        "buildplatform": "windows-latest"
-    },
-    {
-        "goos": "windows",
-        "goarch": "arm",
-        "crossarch": "arm-windows",
-        "buildplatform": "windows-latest"
-    }
-    //
-    // Unsupported targets.
-    //
-    // {
-    //     "goos": "openbsd",
-    //     "goarch": "mips64"
-    // },
-    // {
-    //     "goos": "aix",
-    //     "goarch": "ppc64"
-    // },
-    // {
-    //     "goos": "android",
-    //     "goarch": "386"
-    // },
-    // {
-    //     "goos": "android",
-    //     "goarch": "arm"
-    // },
-    // {
-    //     "goos": "ios",
-    //     "goarch": "amd64"
-    // },
-    // {
-    //     "goos": "ios",
-    //     "goarch": "arm64"
-    // },
-    // {
-    //     "goos": "js",
-    //     "goarch": "wasm"
-    // },
-    // {
-    //     "goos": "linux",
-    //     "goarch": "mips"
-    // },
-    // {
-    //     "goos": "linux",
-    //     "goarch": "mipsle"
-    // },
-    // {
-    //     "goos": "plan9",
-    //     "goarch": "386"
-    // },
-    // {
-    //     "goos": "plan9",
-    //     "goarch": "amd64"
-    // },
-    // {
-    //     "goos": "plan9",
-    //     "goarch": "arm"
-    // }
+  //
+  // 1st class support. We strive to provide best support for these platforms.
+  //
+  {
+    "goos": "darwin",
+    "goarch": "amd64",
+    "buildplatform": "macos-13",
+    "cgo": true,
+    "primary": true
+  },
+  {
+    "goos": "darwin",
+    "goarch": "arm64",
+    "buildplatform": "macos-13",
+    "cgo": true,
+    "primary": true
+  },
+  {
+    "goos": "linux",
+    "goarch": "amd64",
+    "crossarch": "x86_64-linux",
+    "buildtags": "duckdb_from_source",
+    "primary": true
+  },
+  {
+    "goos": "linux",
+    "goarch": "arm64",
+    "crossarch": "aarch64-linux",
+    "primary": true
+  },
+  {
+    "goos": "windows",
+    "goarch": "amd64",
+    "buildplatform": "windows-latest",
+    "cgo": true,
+    "primary": true
+  },
+  {
+    "goos": "windows",
+    "goarch": "arm64",
+    "crossarch": "aarch64-windows",
+    "buildplatform": "windows-latest",
+    "cgo": true,
+    "primary": true
+  },
+  {
+    "goos": "android",
+    "goarch": "arm64"
+  },
+  {
+    "goos": "dragonfly",
+    "goarch": "amd64"
+  },
+  {
+    "goos": "freebsd",
+    "goarch": "386"
+  },
+  {
+    "goos": "freebsd",
+    "goarch": "amd64"
+  },
+  {
+    "goos": "freebsd",
+    "goarch": "arm"
+  },
+  {
+    "goos": "freebsd",
+    "goarch": "arm64"
+  },
+  {
+    "goos": "freebsd",
+    "goarch": "riscv64"
+  },
+  {
+    "goos": "illumos",
+    "goarch": "amd64"
+  },
+  {
+    "goos": "linux",
+    "goarch": "386"
+  },
+  {
+    "goos": "linux",
+    "goarch": "arm"
+  },
+  {
+    "goos": "linux",
+    "goarch": "loong64"
+  },
+  {
+    "goos": "linux",
+    "goarch": "mips64"
+  },
+  {
+    "goos": "linux",
+    "goarch": "mips64le"
+  },
+  {
+    "goos": "linux",
+    "goarch": "ppc64"
+  },
+  {
+    "goos": "linux",
+    "goarch": "ppc64le"
+  },
+  {
+    "goos": "linux",
+    "goarch": "riscv64",
+    "crossarch": "riscv64-linux"
+  },
+  {
+    "goos": "linux",
+    "goarch": "s390x"
+  },
+  {
+    "goos": "netbsd",
+    "goarch": "386"
+  },
+  {
+    "goos": "netbsd",
+    "goarch": "amd64"
+  },
+  {
+    "goos": "netbsd",
+    "goarch": "arm"
+  },
+  {
+    "goos": "netbsd",
+    "goarch": "arm64"
+  },
+  {
+    "goos": "openbsd",
+    "goarch": "386"
+  },
+  {
+    "goos": "openbsd",
+    "goarch": "amd64"
+  },
+  {
+    "goos": "openbsd",
+    "goarch": "arm"
+  },
+  {
+    "goos": "openbsd",
+    "goarch": "arm64"
+  },
+  {
+    "goos": "solaris",
+    "goarch": "amd64"
+  },
+  {
+    "goos": "windows",
+    "goarch": "386",
+    "crossarch": "x86-windows",
+    "buildplatform": "windows-latest"
+  },
+  {
+    "goos": "windows",
+    "goarch": "arm",
+    "crossarch": "arm-windows",
+    "buildplatform": "windows-latest"
+  }
+  //
+  // Unsupported targets.
+  //
+  // {
+  //     "goos": "openbsd",
+  //     "goarch": "mips64"
+  // },
+  // {
+  //     "goos": "aix",
+  //     "goarch": "ppc64"
+  // },
+  // {
+  //     "goos": "android",
+  //     "goarch": "386"
+  // },
+  // {
+  //     "goos": "android",
+  //     "goarch": "arm"
+  // },
+  // {
+  //     "goos": "ios",
+  //     "goarch": "amd64"
+  // },
+  // {
+  //     "goos": "ios",
+  //     "goarch": "arm64"
+  // },
+  // {
+  //     "goos": "js",
+  //     "goarch": "wasm"
+  // },
+  // {
+  //     "goos": "linux",
+  //     "goarch": "mips"
+  // },
+  // {
+  //     "goos": "linux",
+  //     "goarch": "mipsle"
+  // },
+  // {
+  //     "goos": "plan9",
+  //     "goarch": "386"
+  // },
+  // {
+  //     "goos": "plan9",
+  //     "goarch": "amd64"
+  // },
+  // {
+  //     "goos": "plan9",
+  //     "goarch": "arm"
+  // }
 ]
 // vim:ft=jsonc


### PR DESCRIPTION
# What has changed:
- the version of `upload-artifact` and `download-artifact` has been deprecated -> update to latest.
- make sure we run CI/CD on `compile` for the 6 "1st class citizen" platform on PR triggers (but allow for full build by `workflow_dispatch`)
- update the trigger on the CI/CD to essentially:
  - only runs on meaningful events (PRs and master branch)
  - concurrency settings prevent redundant runs