### PR TITLE
test: integration tests for `clickhouse`

### DIFF
--- a/dbee/go.mod
+++ b/dbee/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.4
 
 require (
 	cloud.google.com/go/bigquery v1.61.0
-	github.com/ClickHouse/clickhouse-go/v2 v2.17.1
+	github.com/ClickHouse/clickhouse-go/v2 v2.20.0
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/databricks/databricks-sql-go v1.5.3
 	github.com/go-sql-driver/mysql v1.7.0
@@ -20,6 +20,7 @@ require (
 	github.com/sijms/go-ora/v2 v2.7.6
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.35.0
+	github.com/testcontainers/testcontainers-go/modules/clickhouse v0.35.0
 	github.com/testcontainers/testcontainers-go/modules/gcloud v0.35.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.35.0
 	go.mongodb.org/mongo-driver v1.11.6
@@ -37,10 +38,10 @@ require (
 	cloud.google.com/go/iam v1.1.10 // indirect
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
-	github.com/ClickHouse/ch-go v0.58.2 // indirect
+	github.com/ClickHouse/ch-go v0.61.3 // indirect
 	github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.5.2 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
-	github.com/andybalholm/brotli v1.0.6 // indirect
+	github.com/andybalholm/brotli v1.1.0 // indirect
 	github.com/apache/arrow/go/v12 v12.0.1 // indirect
 	github.com/apache/arrow/go/v14 v14.0.2 // indirect
 	github.com/apache/arrow/go/v15 v15.0.2 // indirect
@@ -64,7 +65,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-faster/city v1.0.1 // indirect
-	github.com/go-faster/errors v0.6.1 // indirect
+	github.com/go-faster/errors v0.7.1 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.3 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -92,7 +93,7 @@ require (
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/klauspost/asmfmt v1.3.2 // indirect
-	github.com/klauspost/compress v1.17.4 // indirect
+	github.com/klauspost/compress v1.17.7 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.5 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
@@ -111,7 +112,7 @@ require (
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
-	github.com/paulmach/orb v0.10.0 // indirect
+	github.com/paulmach/orb v0.11.1 // indirect
 	github.com/pierrec/lz4/v4 v4.1.21 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/dbee/go.sum
+++ b/dbee/go.sum
@@ -636,10 +636,10 @@ github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg6
 github.com/AzureAD/microsoft-authentication-library-for-go v0.8.1/go.mod h1:4qFor3D/HDsvBME35Xy9rwW9DecL+M2sNw1ybjPtwA0=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/ClickHouse/ch-go v0.58.2 h1:jSm2szHbT9MCAB1rJ3WuCJqmGLi5UTjlNu+f530UTS0=
-github.com/ClickHouse/ch-go v0.58.2/go.mod h1:Ap/0bEmiLa14gYjCiRkYGbXvbe8vwdrfTYWhsuQ99aw=
-github.com/ClickHouse/clickhouse-go/v2 v2.17.1 h1:ZCmAYWpu75IyEi7+Yrs/uaAjiCGY5wfW5kXo64exkX4=
-github.com/ClickHouse/clickhouse-go/v2 v2.17.1/go.mod h1:rkGTvFDTLqLIm0ma+13xmcCfr/08Gvs7KmFt1tgiWHQ=
+github.com/ClickHouse/ch-go v0.61.3 h1:MmBwUhXrAOBZK7n/sWBzq6FdIQ01cuF2SaaO8KlDRzI=
+github.com/ClickHouse/ch-go v0.61.3/go.mod h1:1PqXjMz/7S1ZUaKvwPA3i35W2bz2mAMFeCi6DIXgGwQ=
+github.com/ClickHouse/clickhouse-go/v2 v2.20.0 h1:bvlLQ31XJfl7MxIqAq2l1G6JhHYzqEXdvfpMeU6bkKc=
+github.com/ClickHouse/clickhouse-go/v2 v2.20.0/go.mod h1:VQfyA+tCwCRw2G7ogfY8V0fq/r0yJWzy8UDrjiP/Lbs=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.5.2 h1:DBjmt6/otSdULyJdVg2BlG0qGZO5tKL4VzOs0jpvw5Q=
@@ -654,8 +654,8 @@ github.com/ajstarks/deck/generate v0.0.0-20210309230005-c3f852c02e19/go.mod h1:T
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b/go.mod h1:1KcenG0jGWcpt8ov532z81sp/kMMUG485J2InIOyADM=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
-github.com/andybalholm/brotli v1.0.6 h1:Yf9fFpf49Zrxb9NlQaluyE92/+X7UVHlhMNJN2sxfOI=
-github.com/andybalholm/brotli v1.0.6/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
+github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1U3M=
+github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/arrow/go/v10 v10.0.1/go.mod h1:YvhnlEePVnBS4+0z3fhPfUy7W1Ikj0Ih0vcRo/gZ1M0=
 github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4xei5aX110hRiI=
@@ -772,8 +772,8 @@ github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbS
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-faster/city v1.0.1 h1:4WAxSZ3V2Ws4QRDrscLEDcibJY8uf41H6AhXDrNDcGw=
 github.com/go-faster/city v1.0.1/go.mod h1:jKcUJId49qdW3L1qKHH/3wPeUstCVpVSXTM6vO3VcTw=
-github.com/go-faster/errors v0.6.1 h1:nNIPOBkprlKzkThvS/0YaX8Zs9KewLCOSFQS5BU06FI=
-github.com/go-faster/errors v0.6.1/go.mod h1:5MGV2/2T9yvlrbhe9pD9LO5Z/2zCSq2T8j+Jpi2LAyY=
+github.com/go-faster/errors v0.7.1 h1:MkJTnDoEdi9pDabt1dpWf7AA8/BaSYZqibYyhZ20AYg=
+github.com/go-faster/errors v0.7.1/go.mod h1:5ySTjWFiphBs07IKuiL69nxdfd5+fzh1u7FPGZP2quo=
 github.com/go-fonts/dejavu v0.1.0/go.mod h1:4Wt4I4OU2Nq9asgDCteaAaWZOV24E+0/Pwo0gppep4g=
 github.com/go-fonts/latin-modern v0.2.0/go.mod h1:rQVLdDMK+mK1xscDwsqM5J8U2jrRa3T0ecnM9pNujks=
 github.com/go-fonts/liberation v0.1.1/go.mod h1:K6qoJYypsmfVjWg8KOVDQhLc8UDgIK2HYqyqAO9z7GY=
@@ -988,8 +988,8 @@ github.com/klauspost/asmfmt v1.3.2 h1:4Ri7ox3EwapiOjCki+hw14RyKk201CN4rzyCJRFLpK
 github.com/klauspost/asmfmt v1.3.2/go.mod h1:AG8TuvYojzulgDAMCnYn50l/5QV3Bs/tp6j0HLHbNSE=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
-github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
-github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
+github.com/klauspost/compress v1.17.7 h1:ehO88t2UGzQK66LMdE8tibEd1ErmzZjNEqWkjLAKQQg=
+github.com/klauspost/compress v1.17.7/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.5 h1:0E5MSMDEoAulmXNFquVs//DdoomxaoTY1kUhbc/qbZg=
 github.com/klauspost/cpuid/v2 v2.2.5/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
@@ -1061,8 +1061,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
-github.com/paulmach/orb v0.10.0 h1:guVYVqzxHE/CQ1KpfGO077TR0ATHSNjp4s6XGLn3W9s=
-github.com/paulmach/orb v0.10.0/go.mod h1:5mULz1xQfs3bmQm63QEJA6lNGujuRafwA5S/EnuLaLU=
+github.com/paulmach/orb v0.11.1 h1:3koVegMC4X/WeiXYz9iswopaTwMem53NzTJuTF20JzU=
+github.com/paulmach/orb v0.11.1/go.mod h1:5mULz1xQfs3bmQm63QEJA6lNGujuRafwA5S/EnuLaLU=
 github.com/paulmach/protoscan v0.2.1/go.mod h1:SpcSwydNLrxUGSDvXvO0P7g7AuhJ7lcKfDlhJCDw2gY=
 github.com/phpdave11/gofpdf v1.4.2/go.mod h1:zpO6xFn9yxo3YLyMvW8HcKWVdbNqgIfOOp2dXMnm1mY=
 github.com/phpdave11/gofpdi v1.0.12/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
@@ -1143,6 +1143,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/testcontainers/testcontainers-go v0.35.0 h1:uADsZpTKFAtp8SLK+hMwSaa+X+JiERHtd4sQAFmXeMo=
 github.com/testcontainers/testcontainers-go v0.35.0/go.mod h1:oEVBj5zrfJTrgjwONs1SsRbnBtH9OKl+IGl3UMcr2B4=
+github.com/testcontainers/testcontainers-go/modules/clickhouse v0.35.0 h1:A4NESGwof4RK+i/pjL0lAVu0JxNZIvLR35ZFB9DKgYQ=
+github.com/testcontainers/testcontainers-go/modules/clickhouse v0.35.0/go.mod h1:nT0LQ4rqTljX5Ub0Q3GdFrVXRYSrjK6p7RuJPpUE4wg=
 github.com/testcontainers/testcontainers-go/modules/gcloud v0.35.0 h1:8tdSCu4ey2ye3pXjo4I0GPcnYZb66dJN3qN6Ebqpjcg=
 github.com/testcontainers/testcontainers-go/modules/gcloud v0.35.0/go.mod h1:jtvudSR4XxV/NTRHfhD5/wf2xlF5OPuiQmNSB0PM6XM=
 github.com/testcontainers/testcontainers-go/modules/postgres v0.35.0 h1:eEGx9kYzZb2cNhRbBrNOCL/YPOM7+RMJiy3bB+ie0/I=

--- a/dbee/tests/integration/clickhouse_integration_test.go
+++ b/dbee/tests/integration/clickhouse_integration_test.go
@@ -1,0 +1,181 @@
+package integration
+
+import (
+	"context"
+	"log"
+	"testing"
+
+	"github.com/kndndrj/nvim-dbee/dbee/core"
+	th "github.com/kndndrj/nvim-dbee/dbee/tests/testhelpers"
+	"github.com/stretchr/testify/assert"
+	tsuite "github.com/stretchr/testify/suite"
+	tc "github.com/testcontainers/testcontainers-go"
+)
+
+// ClickHouseTestSuite is the test suite for the clickhouse adapter.
+type ClickHouseTestSuite struct {
+	tsuite.Suite
+	ctr *th.ClickHouseContainer
+	ctx context.Context
+	d   *core.Connection
+}
+
+func TestClickHouseTestSuite(t *testing.T) {
+	tsuite.Run(t, new(ClickHouseTestSuite))
+}
+
+func (suite *ClickHouseTestSuite) SetupSuite() {
+	suite.ctx = context.Background()
+	ctr, err := th.NewClickHouseContainer(suite.ctx, &core.ConnectionParams{
+		ID:   "test-clickhouse",
+		Name: "test-clickhouse",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	suite.ctr = ctr
+	suite.d = ctr.Driver
+}
+
+func (suite *ClickHouseTestSuite) TeardownSuite() {
+	tc.CleanupContainer(suite.T(), suite.ctr)
+}
+
+func (suite *ClickHouseTestSuite) TestShouldErrorInvalidQuery() {
+	t := suite.T()
+
+	want := "Syntax error"
+
+	call := suite.d.Execute("invalid sql", func(cs core.CallState, c *core.Call) {
+		if cs == core.CallStateExecutingFailed {
+			assert.ErrorContains(t, c.Err(), want)
+		}
+	})
+	assert.NotNil(t, call)
+}
+
+func (suite *ClickHouseTestSuite) TestShouldCancelQuery() {
+	t := suite.T()
+	want := []core.CallState{core.CallStateExecuting, core.CallStateCanceled}
+
+	_, got, err := th.GetResultWithCancel(t, suite.d, "SELECT 1")
+	assert.NoError(t, err)
+
+	assert.Equal(t, want, got)
+}
+
+func (suite *ClickHouseTestSuite) TestShouldReturnManyRows() {
+	t := suite.T()
+
+	wantStates := []core.CallState{
+		core.CallStateExecuting, core.CallStateRetrieving, core.CallStateArchived,
+	}
+	wantCols := []string{"id", "username"}
+	wantRows := []core.Row{
+		{uint32(1), "john_doe"},
+		{uint32(2), "jane_smith"},
+	}
+
+	query := "SELECT id, username FROM test.test_view"
+
+	gotRows, gotCols, gotStates, err := th.GetResult(t, suite.d, query)
+	assert.NoError(t, err)
+
+	assert.ElementsMatch(t, wantCols, gotCols)
+	assert.ElementsMatch(t, wantStates, gotStates)
+	assert.Equal(t, wantRows, gotRows)
+}
+
+func (suite *ClickHouseTestSuite) TestShouldReturnOneRow() {
+	t := suite.T()
+
+	wantStates := []core.CallState{
+		core.CallStateExecuting, core.CallStateRetrieving, core.CallStateArchived,
+	}
+	wantCols := []string{"id", "username"}
+	wantRows := []core.Row{{uint32(1), "john_doe"}}
+
+	query := "SELECT id, username FROM test.test_table WHERE id = 1"
+
+	gotRows, gotCols, gotStates, err := th.GetResult(t, suite.d, query)
+	assert.NoError(t, err)
+
+	assert.ElementsMatch(t, wantCols, gotCols)
+	assert.ElementsMatch(t, wantStates, gotStates)
+	assert.Equal(t, wantRows, gotRows)
+}
+
+func (suite *ClickHouseTestSuite) TestShouldReturnStructure() {
+	t := suite.T()
+
+	var (
+		wantSomeSchema = "test"
+		wantSomeTable  = "test_table"
+		wantSomeView   = "test_view"
+	)
+
+	structure, err := suite.d.GetStructure()
+	assert.NoError(t, err)
+
+	gotSchemas := th.GetSchemas(t, structure)
+	assert.Contains(t, gotSchemas, wantSomeSchema)
+
+	gotTables := th.GetModels(t, structure, core.StructureTypeTable)
+	assert.Contains(t, gotTables, wantSomeTable)
+
+	gotViews := th.GetModels(t, structure, core.StructureTypeView)
+	assert.Contains(t, gotViews, wantSomeView)
+}
+
+func (suite *ClickHouseTestSuite) TestShouldReturnColumns() {
+	t := suite.T()
+
+	want := []*core.Column{
+		{Name: "id", Type: "UInt32"},
+		{Name: "username", Type: "String"},
+		{Name: "email", Type: "String"},
+		{Name: "created_at", Type: "DateTime"},
+		{Name: "is_active", Type: "UInt8"},
+	}
+
+	got, err := suite.d.GetColumns(&core.TableOptions{
+		Table:           "test_table",
+		Schema:          "test",
+		Materialization: core.StructureTypeTable,
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func (suite *ClickHouseTestSuite) TestShouldSwitchDatabase() {
+	t := suite.T()
+
+	want := "dev"
+	wantAllExceptCurrent := []string{"default", "information_schema", "system", "test"}
+
+	err := suite.d.SelectDatabase(want)
+	assert.NoError(t, err)
+
+	got, gotAllExceptCurrent, err := suite.d.ListDatabases()
+	assert.NoError(t, err)
+	assert.Equal(t, want, got)
+	assert.Equal(t, wantAllExceptCurrent, gotAllExceptCurrent)
+}
+
+func (suite *ClickHouseTestSuite) TestShouldFailSwitchDatabase() {
+	t := suite.T()
+
+	want := "doesnt exist"
+	// create a new connection to avoid changing the default database
+	driver, err := suite.ctr.NewDriver(&core.ConnectionParams{
+		ID:   "test-clickhouse-2",
+		Name: "test-clickhouse-2",
+	})
+	assert.NoError(t, err)
+
+	err = driver.SelectDatabase(want)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), want)
+}

--- a/dbee/tests/testdata/clickhouse_seed.sql
+++ b/dbee/tests/testdata/clickhouse_seed.sql
@@ -1,0 +1,25 @@
+CREATE DATABASE IF NOT EXISTS test;
+
+CREATE TABLE IF NOT EXISTS test.test_table
+(
+    id UInt32,
+    username String,
+    email String,
+    created_at DateTime,
+    is_active UInt8
+) ENGINE = MergeTree()
+ORDER BY id
+;
+
+INSERT INTO test.test_table (id, username, email, created_at, is_active) VALUES
+    (1, 'john_doe', 'john@example.com', '2023-01-01 10:00:00', 1),
+    (2, 'jane_smith', 'jane@example.com', '2023-01-02 11:30:00', 1),
+    (3, 'bob_wilson', 'bob@example.com', '2023-01-03 09:15:00', 0)
+;
+
+CREATE VIEW IF NOT EXISTS test.test_view AS
+SELECT id, username, email, created_at
+FROM test.test_table
+WHERE is_active = 1
+;
+

--- a/dbee/tests/testhelpers/clickhouse.go
+++ b/dbee/tests/testhelpers/clickhouse.go
@@ -1,0 +1,76 @@
+package testhelpers
+
+import (
+	"context"
+
+	"github.com/kndndrj/nvim-dbee/dbee/adapters"
+	"github.com/kndndrj/nvim-dbee/dbee/core"
+	tc "github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/clickhouse"
+)
+
+type ClickHouseContainer struct {
+	*clickhouse.ClickHouseContainer
+	ConnURL string
+	Driver  *core.Connection
+}
+
+// NewClickHouseContainer creates a new clickhouse container with
+// default adapter and connection. The params.URL is overwritten.
+func NewClickHouseContainer(ctx context.Context, params *core.ConnectionParams) (*ClickHouseContainer, error) {
+	seedFile, err := GetTestDataFile("clickhouse_seed.sql")
+	if err != nil {
+		return nil, err
+	}
+
+	ctr, err := clickhouse.Run(
+		ctx,
+		"clickhouse/clickhouse-server:25.1-alpine",
+		tc.CustomizeRequest(tc.GenericContainerRequest{
+			ProviderType: GetContainerProvider(),
+		}),
+		clickhouse.WithUsername("admin"),
+		clickhouse.WithPassword(""),
+		clickhouse.WithDatabase("dev"),
+		clickhouse.WithInitScripts(seedFile.Name()),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	connURL, err := ctr.ConnectionString(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if params.Type == "" {
+		params.Type = "clickhouse"
+	}
+
+	if params.URL == "" {
+		params.URL = connURL
+	}
+
+	driver, err := adapters.NewConnection(params)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ClickHouseContainer{
+		ClickHouseContainer: ctr,
+		ConnURL:             connURL,
+		Driver:              driver,
+	}, nil
+}
+
+// NewDriver helper function to create a new driver with the connection URL.
+func (p *ClickHouseContainer) NewDriver(params *core.ConnectionParams) (*core.Connection, error) {
+	if params.URL == "" {
+		params.URL = p.ConnURL
+	}
+	if params.Type == "" {
+		params.Type = "clickhouse"
+	}
+
+	return adapters.NewConnection(params)
+}

--- a/dbee/tests/testhelpers/helper.go
+++ b/dbee/tests/testhelpers/helper.go
@@ -48,7 +48,7 @@ func GetResult(t *testing.T, d *core.Connection, query string) ([]core.Row, core
 		outStates = append(outStates, state)
 
 		var err error
-		if state == core.CallStateRetrieving {
+		if state == core.CallStateArchived || state == core.CallStateRetrieving {
 			result, err = c.GetResult()
 			require.NoError(t, err, "failed getting result with %s, err: %s", state, c.Err())
 			outRows, err = result.Rows(0, result.Len())


### PR DESCRIPTION
# What has changed:
- add basic integration tests structure for `clickhouse` adapter
- add ping check on the connection to make sure it is connected succesfully
- revert switch database if fails etc
- update `GetResult` in testhelpers to fetch result for `CallStateArchived` state