### PR TITLE
test: integration tests for `duckdb`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,4 +66,4 @@ jobs:
           check-latest: true
           cache-dependency-path: ./dbee/go.sum
       - name: Run Integration Tests
-        run: go test ./tests/integration/${{ matrix.adapter }}_integration_test.go -v
+        run: sudo go test ./tests/integration/${{ matrix.adapter }}_integration_test.go -v

--- a/dbee/adapters/duck.go
+++ b/dbee/adapters/duck.go
@@ -26,8 +26,11 @@ type Duck struct{}
 // Helper function to get database from url
 func parseDatabaseFromPath(path string) string {
 	base := filepath.Base(path)
-	name := strings.TrimSuffix(base, filepath.Ext(base))
-	return name
+	parts := strings.Split(base, ".")
+	if len(parts) > 1 && parts[0] == "" {
+		parts = parts[1:]
+	}
+	return parts[0]
 }
 
 func (d *Duck) Connect(url string) (core.Driver, error) {

--- a/dbee/adapters/duck.go
+++ b/dbee/adapters/duck.go
@@ -39,14 +39,14 @@ func (d *Duck) Connect(url string) (core.Driver, error) {
 		return nil, fmt.Errorf("unable to connect to duckdb database: %v", err)
 	}
 
-	currentCatalog := "memory"
+	currentDB := "memory"
 	if url != "" {
-		currentCatalog = parseDatabaseFromPath(url)
+		currentDB = parseDatabaseFromPath(url)
 	}
 
 	return &duckDriver{
 		c:              builders.NewClient(db),
-		currentCatalog: currentCatalog,
+		currentDB: currentDB,
 	}, nil
 }
 

--- a/dbee/adapters/duck_driver.go
+++ b/dbee/adapters/duck_driver.go
@@ -18,36 +18,37 @@ func (c *duckDriver) Query(ctx context.Context, query string) (core.ResultStream
 }
 
 func (c *duckDriver) Columns(opts *core.TableOptions) ([]*core.Column, error) {
-	return c.c.ColumnsFromQuery("DESCRIBE %q", opts.Table)
+	return c.c.ColumnsFromQuery("DESCRIBE %q.%q", opts.Schema, opts.Table)
 }
 
 func (c *duckDriver) Structure() ([]*core.Structure, error) {
-	query := `SHOW TABLES;`
+	catalogQuery := `
+		SELECT table_schema, table_name, table_type
+		FROM information_schema.tables;`
 
-	rows, err := c.Query(context.TODO(), query)
+	rows, err := c.Query(context.Background(), catalogQuery)
 	if err != nil {
 		return nil, err
 	}
 
-	var schema []*core.Structure
-	for rows.HasNext() {
-		row, err := rows.Next()
-		if err != nil {
-			return nil, err
-		}
-
-		// We know for a fact there is only one string field (see query above)
-		table := row[0].(string)
-		schema = append(schema, &core.Structure{
-			Name:   table,
-			Schema: "",
-			Type:   core.StructureTypeTable,
-		})
-	}
-
-	return schema, nil
+	return core.GetGenericStructure(rows, getDuckDBStructureType)
 }
 
+// getDuckDBStructureType returns the core.StructureType based on the
+// given type string for duckdb adapter.
+func getDuckDBStructureType(typ string) core.StructureType {
+	// TODO: (phdah) Add more types if exists
+	switch typ {
+	case "BASE TABLE":
+		return core.StructureTypeTable
+	case "VIEW":
+		return core.StructureTypeView
+	default:
+		return core.StructureTypeNone
+	}
+}
+
+// Close closes the connection to the database.
 func (c *duckDriver) Close() {
 	c.c.Close()
 }

--- a/dbee/adapters/duck_driver.go
+++ b/dbee/adapters/duck_driver.go
@@ -15,7 +15,7 @@ var (
 
 type duckDriver struct {
 	c              *builders.Client
-	currentCatalog string
+	currentDB string
 }
 
 func (d *duckDriver) Query(ctx context.Context, query string) (core.ResultStream, error) {
@@ -31,7 +31,7 @@ func (d *duckDriver) Structure() ([]*core.Structure, error) {
 		SELECT table_schema, table_name, table_type
 		FROM information_schema.tables
 		WHERE table_catalog = '%s';`,
-		d.currentCatalog)
+		d.currentDB)
 
 	rows, err := d.Query(context.Background(), catalogQuery)
 	if err != nil {
@@ -60,7 +60,7 @@ func getDuckDBStructureType(typ string) core.StructureType {
 // current will be shown
 func (d *duckDriver) ListDatabases() (current string, available []string, err error) {
 	// no-op
-	return d.currentCatalog, []string{d.currentCatalog}, nil
+	return d.currentDB, []string{d.currentDB}, nil
 }
 
 // SelectDatabase switches the current database/catalog to the selected one.

--- a/dbee/adapters/duck_driver.go
+++ b/dbee/adapters/duck_driver.go
@@ -60,13 +60,12 @@ func getDuckDBStructureType(typ string) core.StructureType {
 // current will be shown
 func (d *duckDriver) ListDatabases() (current string, available []string, err error) {
 	// no-op
-	return d.currentDB, []string{d.currentDB}, nil
+	return d.currentDB, []string{"not supported yet"}, nil
 }
 
 // SelectDatabase switches the current database/catalog to the selected one.
-// NOTE: (phdah) As of now, swapping catalogs is not enabled
 func (d *duckDriver) SelectDatabase(name string) error {
-	return fmt.Errorf("SelectDabase method not implemented yet")
+	return nil
 }
 
 // Close closes the connection to the database.

--- a/dbee/adapters/duck_driver.go
+++ b/dbee/adapters/duck_driver.go
@@ -18,22 +18,22 @@ type duckDriver struct {
 	currentCatalog string
 }
 
-func (c *duckDriver) Query(ctx context.Context, query string) (core.ResultStream, error) {
-	return c.c.QueryUntilNotEmpty(ctx, query)
+func (d *duckDriver) Query(ctx context.Context, query string) (core.ResultStream, error) {
+	return d.c.QueryUntilNotEmpty(ctx, query)
 }
 
-func (c *duckDriver) Columns(opts *core.TableOptions) ([]*core.Column, error) {
-	return c.c.ColumnsFromQuery("DESCRIBE %q.%q", opts.Schema, opts.Table)
+func (d *duckDriver) Columns(opts *core.TableOptions) ([]*core.Column, error) {
+	return d.c.ColumnsFromQuery("DESCRIBE %q.%q", opts.Schema, opts.Table)
 }
 
-func (c *duckDriver) Structure() ([]*core.Structure, error) {
+func (d *duckDriver) Structure() ([]*core.Structure, error) {
 	catalogQuery := fmt.Sprintf(`
 		SELECT table_schema, table_name, table_type
 		FROM information_schema.tables
 		WHERE table_catalog = '%s';`,
-		c.currentCatalog)
+		d.currentCatalog)
 
-	rows, err := c.Query(context.Background(), catalogQuery)
+	rows, err := d.Query(context.Background(), catalogQuery)
 	if err != nil {
 		return nil, err
 	}
@@ -58,19 +58,18 @@ func getDuckDBStructureType(typ string) core.StructureType {
 // ListDatabases returns the current catalog and a list of available catalogs.
 // NOTE: (phdah) As of now, swapping catalogs is not enabled and only the
 // current will be shown
-func (c *duckDriver) ListDatabases() (current string, available []string, err error) {
+func (d *duckDriver) ListDatabases() (current string, available []string, err error) {
 	// no-op
-	return c.currentCatalog, []string{c.currentCatalog}, nil
+	return d.currentCatalog, []string{d.currentCatalog}, nil
 }
 
 // SelectDatabase switches the current database/catalog to the selected one.
 // NOTE: (phdah) As of now, swapping catalogs is not enabled
-func (c *duckDriver) SelectDatabase(name string) error {
-	// no-op
-	return nil
+func (d *duckDriver) SelectDatabase(name string) error {
+	return fmt.Errorf("SelectDabase method not implemented yet")
 }
 
 // Close closes the connection to the database.
-func (c *duckDriver) Close() {
-	c.c.Close()
+func (d *duckDriver) Close() {
+	d.c.Close()
 }

--- a/dbee/adapters/duck_driver_test.go
+++ b/dbee/adapters/duck_driver_test.go
@@ -1,0 +1,47 @@
+package adapters
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_parseDatabaseFromPath(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "should return `test` part from unix file path",
+			input: "/tmp/test.db",
+			want:  "test",
+		},
+		{
+			name:  "should return `.hiddenFile` part from unix file path",
+			input: "/tmp/.hiddenFile.db",
+			want:  "hiddenFile",
+		},
+		{
+			name:  "should return `my_file` part from file url path",
+			input: "file:///tmp/my_file.database",
+			want:  "my_file",
+		},
+		{
+			name:  "should return `my_db` part from s3 bucket url",
+			input: "s3://bucket_name/path/to/my_db.duckdb",
+			want:  "my_db",
+		},
+		{
+			name:  "should return `remote_db` part from https url",
+			input: "https://www.example.com/remote_db.example.new",
+			want:  "remote_db",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseDatabaseFromPath(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/dbee/tests/integration/duckdb_integration_test.go
+++ b/dbee/tests/integration/duckdb_integration_test.go
@@ -1,0 +1,206 @@
+package integration
+
+import (
+	"context"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/kndndrj/nvim-dbee/dbee/core"
+	th "github.com/kndndrj/nvim-dbee/dbee/tests/testhelpers"
+	"github.com/stretchr/testify/assert"
+	tsuite "github.com/stretchr/testify/suite"
+)
+
+// DuckDBTestSuite defines the integration test suite for DuckDB.
+type DuckDBTestSuite struct {
+	tsuite.Suite
+	ctr *th.DuckDBContainer
+	ctx context.Context
+	d   *core.Connection
+}
+
+// TestDuckDBTestSuite runs the test suite.
+func TestDuckDBTestSuite(t *testing.T) {
+	tsuite.Run(t, new(DuckDBTestSuite))
+}
+
+// SetupSuite initializes an in-memory DuckDB instance.
+func (suite *DuckDBTestSuite) SetupSuite() {
+	suite.ctx = context.Background()
+	ctr, err := th.NewDuckDBContainer(&core.ConnectionParams{
+		ID:   "test-duckdb",
+		Name: "test-duckdb",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	suite.ctr = ctr
+	suite.d = ctr.Driver // easier access to driver
+
+	// Create test table and insert random data
+	setupSQL := `
+		CREATE SCHEMA test;
+		CREATE TABLE test.users (
+			id INTEGER PRIMARY KEY,
+			name TEXT NOT NULL,
+			created_at TIMESTAMP NOT NULL
+		);
+		INSERT INTO test.users (id, name, created_at) VALUES
+		(1, 'john', '2025-01-21 00:00:00'),
+		(2, 'bob', '2025-01-21 00:01:00');
+	`
+
+	call := suite.d.Execute(setupSQL, nil)
+	// TODO: (ph) not sure on thi
+	err = call.Err()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+// TeardownSuite cleans up after tests.
+func (suite *DuckDBTestSuite) TeardownSuite() {
+	suite.d.Close()
+}
+
+func (suite *DuckDBTestSuite) TestShouldCancelQuery() {
+	t := suite.T()
+	want := []core.CallState{core.CallStateExecuting, core.CallStateCanceled}
+
+	_, got, err := th.GetResultWithCancel(t, suite.d, "SELECT COUNT(*) FROM range(5000000000)")
+	assert.NoError(t, err)
+
+	assert.Equal(t, want, got)
+}
+
+// TestShouldReturnRows validates data retrieval for one rows.
+func (suite *DuckDBTestSuite) TestShouldReturnOneRows() {
+	t := suite.T()
+
+	wantStates := []core.CallState{
+		core.CallStateExecuting, core.CallStateRetrieving, core.CallStateArchived,
+	}
+	wantCols := []string{
+		"id", "name", "created_at",
+	}
+	wantRows := []core.Row{
+		{
+			int32(1),
+			"john",
+			time.Date(2025, 1, 21, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	query := "SELECT id, name, created_at FROM test.users WHERE id = 1"
+
+	gotRows, gotCols, gotStates, err := th.GetResult(t, suite.d, query)
+	assert.NoError(t, err)
+
+	assert.ElementsMatch(t, wantCols, gotCols)
+	assert.ElementsMatch(t, wantStates, gotStates)
+	assert.Equal(t, wantRows, gotRows)
+}
+
+// TestShouldReturnRows validates data retrieval for all rows.
+func (suite *DuckDBTestSuite) TestShouldReturnManyRows() {
+	t := suite.T()
+
+	wantStates := []core.CallState{
+		core.CallStateExecuting, core.CallStateRetrieving, core.CallStateArchived,
+	}
+	wantCols := []string{
+		"id", "name", "created_at",
+	}
+	wantRows := []core.Row{
+		{
+			int32(1),
+			"john",
+			time.Date(2025, 1, 21, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			int32(2),
+			"bob",
+			time.Date(2025, 1, 21, 0, 1, 0, 0, time.UTC),
+		},
+	}
+
+	query := "SELECT id, name, created_at FROM test.users"
+
+	gotRows, gotCols, gotStates, err := th.GetResult(t, suite.d, query)
+	assert.NoError(t, err)
+
+	assert.ElementsMatch(t, wantCols, gotCols)
+	assert.ElementsMatch(t, wantStates, gotStates)
+	assert.Equal(t, wantRows, gotRows)
+}
+
+// TestShouldFailInvalidQuery ensures invalid SQL fails.
+func (suite *DuckDBTestSuite) TestShouldFailInvalidQuery() {
+	t := suite.T()
+
+	want := "syntax error"
+
+	call := suite.d.Execute("INVALID SQL", func(cs core.CallState, c *core.Call) {
+		if cs == core.CallStateExecutingFailed {
+			assert.ErrorContains(t, c.Err(), want)
+		}
+	})
+	assert.NotNil(t, call)
+}
+
+// TestShouldReturnColumns validates column metadata.
+func (suite *DuckDBTestSuite) TestShouldReturnColumns() {
+	t := suite.T()
+
+	want := []*core.Column{
+		{Name: "id", Type: "INTEGER"},
+		{Name: "name", Type: "VARCHAR"},
+		{Name: "created_at", Type: "TIMESTAMP"},
+	}
+
+	got, err := suite.d.GetColumns(&core.TableOptions{
+		Table:           "users",
+		Schema:          "test",
+		Materialization: core.StructureTypeTable,
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+// TestShouldReturnStructure validates the schema structure.
+func (suite *DuckDBTestSuite) TestShouldReturnStructure() {
+	t := suite.T()
+
+	wantSchemas := []string{"test"}
+	wantTables := []string{"users"}
+
+	structure, err := suite.d.GetStructure()
+	assert.NoError(t, err)
+
+	gotTables := th.GetModels(t, structure, core.StructureTypeTable)
+	gotSchemas := th.GetSchemas(t, structure)
+	assert.ElementsMatch(t, wantTables, gotTables)
+	assert.ElementsMatch(t, wantSchemas, gotSchemas)
+}
+
+// TestShouldFailSwitchDatabase validates error connecting to database that
+// doesn't exist
+func (suite *DuckDBTestSuite) TestShouldFailSwitchDatabase() {
+	t := suite.T()
+
+	want := "database switching not supported"
+	// create a new connection to avoid changing the default database
+	driver, err := suite.ctr.NewDriver(&core.ConnectionParams{
+		ID:   "test-duckdb-2",
+		Name: "test-duckdb-2",
+	})
+	assert.NoError(t, err)
+
+	newDatabase := "doesnt exist"
+	err = driver.SelectDatabase(newDatabase)
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), want)
+}

--- a/dbee/tests/integration/duckdb_integration_test.go
+++ b/dbee/tests/integration/duckdb_integration_test.go
@@ -186,21 +186,15 @@ func (suite *DuckDBTestSuite) TestShouldReturnStructure() {
 	assert.ElementsMatch(t, wantSchemas, gotSchemas)
 }
 
-// TestShouldFailSwitchDatabase validates error connecting to database that
-// doesn't exist
-func (suite *DuckDBTestSuite) TestShouldFailSwitchDatabase() {
+// TestListOnlyOneDatabase validates listing database only return a single database.
+// NOTE: (phdah) As of now, swapping catalogs is not enabled
+func (suite *DuckDBTestSuite) TestListOnlyOneDatabase() {
 	t := suite.T()
 
-	want := "database switching not supported"
-	// create a new connection to avoid changing the default database
-	driver, err := suite.ctr.NewDriver(&core.ConnectionParams{
-		ID:   "test-duckdb-2",
-		Name: "test-duckdb-2",
-	})
+	wantCurrent := "memory"
+	wantAvailable := []string{"memory"}
+	gotCurrent, gotAvailable, err := suite.d.ListDatabases()
 	assert.NoError(t, err)
-
-	newDatabase := "doesnt exist"
-	err = driver.SelectDatabase(newDatabase)
-	assert.Error(t, err)
-	assert.Equal(t, err.Error(), want)
+	assert.Equal(t, wantCurrent, gotCurrent)
+	assert.Equal(t, wantAvailable, gotAvailable)
 }

--- a/dbee/tests/testdata/duckdb_seed.sql
+++ b/dbee/tests/testdata/duckdb_seed.sql
@@ -1,0 +1,18 @@
+CREATE SCHEMA IF NOT EXISTS test;
+
+CREATE TABLE IF NOT EXISTS test.test_table (
+    id INTEGER PRIMARY KEY,
+    username TEXT NOT NULL,
+    email TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL
+);
+
+INSERT INTO test.test_table (id, username, email, created_at) VALUES
+    (1, 'john_doe', 'john@example.com', '2023-01-01 10:00:00'),
+    (2, 'jane_smith', 'jane@example.com', '2023-01-02 11:30:00'),
+    (3, 'bob_wilson', 'bob@example.com', '2023-01-03 09:15:00');
+
+CREATE OR REPLACE VIEW test.test_view AS
+SELECT id, username, email
+FROM test.test_table
+WHERE id = 2;

--- a/dbee/tests/testdata/duckdb_seed.sql
+++ b/dbee/tests/testdata/duckdb_seed.sql
@@ -1,18 +1,18 @@
-CREATE SCHEMA IF NOT EXISTS test;
+CREATE SCHEMA IF NOT EXISTS test_container.test_schema;
 
-CREATE TABLE IF NOT EXISTS test.test_table (
+CREATE TABLE IF NOT EXISTS test_container.test_schema.test_table (
     id INTEGER PRIMARY KEY,
     username TEXT NOT NULL,
     email TEXT NOT NULL,
     created_at TIMESTAMP NOT NULL
 );
 
-INSERT INTO test.test_table (id, username, email, created_at) VALUES
+INSERT INTO test_container.test_schema.test_table (id, username, email, created_at) VALUES
     (1, 'john_doe', 'john@example.com', '2023-01-01 10:00:00'),
     (2, 'jane_smith', 'jane@example.com', '2023-01-02 11:30:00'),
     (3, 'bob_wilson', 'bob@example.com', '2023-01-03 09:15:00');
 
-CREATE OR REPLACE VIEW test.test_view AS
+CREATE OR REPLACE VIEW test_container.test_schema.test_view AS
 SELECT id, username, email
-FROM test.test_table
+FROM test_container.test_schema.test_table
 WHERE id = 2;

--- a/dbee/tests/testhelpers/duckdb.go
+++ b/dbee/tests/testhelpers/duckdb.go
@@ -1,0 +1,42 @@
+package testhelpers
+
+import (
+	"github.com/kndndrj/nvim-dbee/dbee/adapters"
+	"github.com/kndndrj/nvim-dbee/dbee/core"
+)
+
+// DuckDBContainer represents an in-memory DuckDB instance.
+type DuckDBContainer struct {
+	Driver *core.Connection
+}
+
+// NewDuckDBContainer creates a new in-memory DuckDB instance.
+func NewDuckDBContainer(params *core.ConnectionParams) (*DuckDBContainer, error) {
+	if params.Type == "" {
+		params.Type = "duckdb"
+	}
+	if params.URL != "" {
+		params.URL = ""
+	}
+
+	driver, err := adapters.NewConnection(params)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DuckDBContainer{
+		Driver: driver,
+	}, nil
+}
+
+// NewDriver helper function to create a new driver with the same connection.
+func (d *DuckDBContainer) NewDriver(params *core.ConnectionParams) (*core.Connection, error) {
+	if params.Type == "" {
+		params.Type = "duckdb"
+	}
+	if params.URL != "" {
+		params.URL = ""
+	}
+
+	return adapters.NewConnection(params)
+}

--- a/dbee/tests/testhelpers/duckdb.go
+++ b/dbee/tests/testhelpers/duckdb.go
@@ -1,36 +1,80 @@
 package testhelpers
 
 import (
-	"io"
-	"log"
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
 
+	"github.com/docker/docker/api/types/container"
 	"github.com/kndndrj/nvim-dbee/dbee/adapters"
 	"github.com/kndndrj/nvim-dbee/dbee/core"
+	tc "github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 // DuckDBContainer represents an in-memory DuckDB instance.
 type DuckDBContainer struct {
-	Driver *core.Connection
+	tc.Container
+	ConnURL string
+	Driver  *core.Connection
+	TempDir string
 }
 
-// NewDuckDBContainer creates a new in-memory DuckDB instance.
-func NewDuckDBContainer(params *core.ConnectionParams) (*DuckDBContainer, error) {
+// NewDuckDBContainer creates a new duckdb container with
+// default adapter and connection. The params.URL is overwritten.
+// It uses a temporary directory (usually the test suite tempDir) to store the db file.
+// The tmpDir is then mounted to the container and all the dependencies are installed
+// in the container file, while still being able to connect to the db file in the host.
+func NewDuckDBContainer(ctx context.Context, params *core.ConnectionParams, tmpDir string) (*DuckDBContainer, error) {
 	seedFile, err := GetTestDataFile("duckdb_seed.sql")
 	if err != nil {
 		return nil, err
 	}
-	// Read the file contents into a string
-	content, err := io.ReadAll(seedFile)
+
+	dbName, containerDBPath := "test_container.db", "/container/db"
+	entrypointCmd := []string{
+		"apt-get update",
+		"apt-get install -y curl",
+		"curl https://install.duckdb.org | sh",
+		"export PATH='/root/.duckdb/cli/latest':$PATH",
+		fmt.Sprintf("duckdb %s/%s < %s", containerDBPath, dbName, seedFile.Name()),
+		"echo 'ready'",
+		"tail -f /dev/null", // hack to keep the container running indefinitely
+	}
+
+	req := tc.ContainerRequest{
+		Image: "debian:12.10-slim",
+		Files: []tc.ContainerFile{
+			{
+				Reader:            seedFile,
+				ContainerFilePath: seedFile.Name(),
+				FileMode:          0o755,
+			},
+		},
+		HostConfigModifier: func(hc *container.HostConfig) {
+			hc.Binds = append(hc.Binds, fmt.Sprintf("%s:%s", tmpDir, containerDBPath))
+		},
+		Cmd:        []string{"sh", "-c", strings.Join(entrypointCmd, " && ")},
+		WaitingFor: wait.ForLog("ready").WithStartupTimeout(60 * time.Second),
+	}
+
+	ctr, err := tc.GenericContainer(ctx, tc.GenericContainerRequest{
+		ContainerRequest: req,
+		ProviderType:     GetContainerProvider(),
+		Started:          true,
+	})
 	if err != nil {
 		return nil, err
 	}
-	seedQuery := string(content)
 
 	if params.Type == "" {
 		params.Type = "duckdb"
 	}
-	if params.URL != "" {
-		params.URL = ""
+	connURL := filepath.Join(tmpDir, dbName)
+	if params.URL == "" {
+		params.URL = connURL
 	}
 
 	driver, err := adapters.NewConnection(params)
@@ -38,27 +82,21 @@ func NewDuckDBContainer(params *core.ConnectionParams) (*DuckDBContainer, error)
 		return nil, err
 	}
 
-	call := driver.Execute(seedQuery, nil)
-	select {
-	case <-call.Done():
-		err := call.Err()
-		if err != nil {
-			log.Fatal(err)
-		}
-	}
-
 	return &DuckDBContainer{
-		Driver: driver,
+		Container: ctr,
+		ConnURL:   connURL,
+		Driver:    driver,
+		TempDir:   tmpDir,
 	}, nil
 }
 
-// NewDriver helper function to create a new driver with the same connection.
+// NewDriver helper function to create a new driver with the connection URL.
 func (d *DuckDBContainer) NewDriver(params *core.ConnectionParams) (*core.Connection, error) {
 	if params.Type == "" {
 		params.Type = "duckdb"
 	}
 	if params.URL != "" {
-		params.URL = ""
+		params.URL = d.ConnURL
 	}
 
 	return adapters.NewConnection(params)

--- a/dbee/tests/testhelpers/sqlite.go
+++ b/dbee/tests/testhelpers/sqlite.go
@@ -34,7 +34,7 @@ func NewSQLiteContainer(ctx context.Context, params *core.ConnectionParams, tmpD
 
 	dbName, containerDBPath := "test.db", "/container/db"
 	entrypointCmd := []string{
-		"apk add sqlite=3.48.0-r0",
+		"apk add sqlite=3.48.0-r1",
 		fmt.Sprintf("sqlite3 %s/%s < %s", containerDBPath, dbName, seedFile.Name()),
 		"echo 'ready'",
 		"tail -f /dev/null", // hack to keep the container running indefinitely


### PR DESCRIPTION
# Description
This follows the style and structure of both the postgres and bigquery integration tests.

---
# What's left?
_Edit:_ There seems to be some issue with the adapter. Will investigate it. Resolved by commit `98bac14ceda3`:
```
Add Archived state in GetResult to not run async

This is a fix provided by @MattiasMTS in:
http://github.com/kndndrj/nvim-dbee/pull/177/files#diff-5234895d59f82777fe5b7e9e89ec74f054246a480b63d168a00142551ef6c6bcR48
```

- [x] Seems to be a race condition for creating the table returning empty result of the `GetResult()` function.
- [x] The `GetStructure()` returns empty. Not sure if this is expected or not.
  - Resolved by adding more depth to the driver's structure.
- [x] Want to look into if/how we can switch databases (`catalog` in DuckDB).
    - Resolved by adding the current database to show, but not allowing switching

---
# Status
```
    --- PASS: TestDuckDBTestSuite/TestListOnlyOneDatabase (0.00s)
    --- PASS: TestDuckDBTestSuite/TestShouldCancelQuery (0.10s)
    --- PASS: TestDuckDBTestSuite/TestShouldFailInvalidQuery (0.00s)
    --- PASS: TestDuckDBTestSuite/TestShouldReturnColumns (0.00s)
    --- PASS: TestDuckDBTestSuite/TestShouldReturnManyRows (0.10s)
    --- PASS: TestDuckDBTestSuite/TestShouldReturnOneRows (0.11s)
    --- PASS: TestDuckDBTestSuite/TestShouldReturnStructure (0.03s)
```

---
# Fixes
Added schema to DuckDB driver:
![Screenshot 2025-02-05 at 11 30 55](https://github.com/user-attachments/assets/72df7319-2f75-4568-852d-ce73fa1a10b9)
Added catalog
![Screenshot 2025-02-14 at 12 01 02](https://github.com/user-attachments/assets/173dcfed-40eb-40bf-a77c-d1071085e37c)