### PR TITLE
ci(test): add matrix bootstrap for testcontainer parallelization

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,10 +33,32 @@ jobs:
       - name: Run Unit Tests
         run: go test $(go list ./... | grep -v tests) -v
 
-  go-integration-test:
+  bootstrap-testcontainers:
     if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-22.04
-    name: Go Integration Test
+    name: Bootstrap Testcontainers
+    outputs:
+      matrix: ${{ steps.generate-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: generate-matrix
+        run: |
+          # create a JSON object with the adapter names to bootstrap matrix with.
+          matrix=$(find tests/integration -name '*_integration_test.go' -exec basename {} \; \
+            | sed 's/_integration_test.go//' \
+            | jq -scR 'split("\n") | map(select(length > 0)) | {adapter: .}')
+          echo "matrix=$matrix" | tee $GITHUB_OUTPUT
+
+  go-integration-test:
+    needs: bootstrap-testcontainers
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    env:
+      TESTCONTAINERS_RYUK_DISABLED: true
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.bootstrap-testcontainers.outputs.matrix) }}
+    name: Go Integration Test (${{ matrix.adapter }})
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go v${{ env.GO_VERSION }}
@@ -46,4 +68,4 @@ jobs:
           check-latest: true
           cache-dependency-path: ./dbee/go.sum
       - name: Run Integration Tests
-        run: go test ./tests/integration... -v
+        run: go test ./tests/integration/${{ matrix.adapter }}_integration_test.go -v


### PR DESCRIPTION
# What has changed:
Given we are now starting to have a few testcontainer tests, we might want to parallelize them as part of the CI/CD. This is a quick bootstrap to retrieve each adapter file and run it independently.

I realize we have the `./ci` folder, which contains CI/CD scripts. However, I don't think this part need to have it own bash script yet, given it is quite simple/small. I also think it make more sense to "dynamically" detect adapters from the file structure rather than adding the adapter name in the CI/CD part (we want to hide that logic from contributors - they should only care about adding a new 'adapter' test file IMHO).