### PR TITLE
Curser on query windown after query executed

### DIFF
--- a/dbee/core/call.go
+++ b/dbee/core/call.go
@@ -14,11 +14,12 @@ type (
 	CallID string
 
 	Call struct {
-		id        CallID
-		query     string
-		state     CallState
-		timeTaken time.Duration
-		timestamp time.Time
+		id            CallID
+		query         string
+		calliersWinID uint64
+		state         CallState
+		timeTaken     time.Duration
+		timestamp     time.Time
 
 		result     *Result
 		archive    *archive
@@ -32,12 +33,13 @@ type (
 
 // callPersistent is used for marshaling and unmarshaling the call
 type callPersistent struct {
-	ID        string `json:"id"`
-	Query     string `json:"query"`
-	State     string `json:"state"`
-	TimeTaken int64  `json:"time_taken_us"`
-	Timestamp int64  `json:"timestamp_us"`
-	Error     string `json:"error,omitempty"`
+	ID           string `json:"id"`
+	Query        string `json:"query"`
+	CallersWinID uint64 `json:"callers_winid"`
+	State        string `json:"state"`
+	TimeTaken    int64  `json:"time_taken_us"`
+	Timestamp    int64  `json:"timestamp_us"`
+	Error        string `json:"error,omitempty"`
 }
 
 func (c *Call) toPersistent() *callPersistent {
@@ -47,12 +49,13 @@ func (c *Call) toPersistent() *callPersistent {
 	}
 
 	return &callPersistent{
-		ID:        string(c.id),
-		Query:     c.query,
-		State:     c.state.String(),
-		TimeTaken: c.timeTaken.Microseconds(),
-		Timestamp: c.timestamp.UnixMicro(),
-		Error:     errMsg,
+		ID:           string(c.id),
+		Query:        c.query,
+		State:        c.state.String(),
+		CallersWinID: c.calliersWinID,
+		TimeTaken:    c.timeTaken.Microseconds(),
+		Timestamp:    c.timestamp.UnixMicro(),
+		Error:        errMsg,
 	}
 }
 
@@ -186,6 +189,14 @@ func (c *Call) GetID() CallID {
 
 func (c *Call) GetQuery() string {
 	return c.query
+}
+
+func (c *Call) SetCallersWinID(winID uint64) {
+	c.calliersWinID = winID
+}
+
+func (c *Call) GetCallersWinID() uint64 {
+	return c.calliersWinID
 }
 
 func (c *Call) GetState() CallState {

--- a/dbee/endpoints.go
+++ b/dbee/endpoints.go
@@ -93,11 +93,12 @@ func mountEndpoints(p *plugin.Plugin, h *handler.Handler) {
 	p.RegisterEndpoint(
 		"DbeeConnectionExecute",
 		func(args *struct {
-			ID    core.ConnectionID `msgpack:",array"`
-			Query string
+			ID           core.ConnectionID `msgpack:",array"`
+			Query        string
+			CallersWinID uint64
 		},
 		) (any, error) {
-			call, err := h.ConnectionExecute(args.ID, args.Query)
+			call, err := h.ConnectionExecute(args.ID, args.Query, args.CallersWinID)
 			return handler.WrapCall(call), err
 		})
 

--- a/dbee/handler/event_bus.go
+++ b/dbee/handler/event_bus.go
@@ -31,6 +31,7 @@ func (eb *eventBus) CallStateChanged(call *core.Call) {
 		call = {
 			id = %q,
 			query = %q,
+			callers_winid = %d,
 			state = %q,
 			time_taken_us = %d,
 			timestamp_us = %d,
@@ -38,6 +39,7 @@ func (eb *eventBus) CallStateChanged(call *core.Call) {
 		},
 	}`, call.GetID(),
 		call.GetQuery(),
+		call.GetCallersWinID(),
 		call.GetState().String(),
 		call.GetTimeTaken().Microseconds(),
 		call.GetTimestamp().UnixMicro(),

--- a/dbee/handler/handler.go
+++ b/dbee/handler/handler.go
@@ -156,7 +156,7 @@ func (h *Handler) SetCurrentConnection(connID core.ConnectionID) error {
 	return nil
 }
 
-func (h *Handler) ConnectionExecute(connID core.ConnectionID, query string) (*core.Call, error) {
+func (h *Handler) ConnectionExecute(connID core.ConnectionID, query string, callersWinID uint64) (*core.Call, error) {
 	c, ok := h.lookupConnection[connID]
 	if !ok {
 		return nil, fmt.Errorf("unknown connection with id: %q", connID)
@@ -170,6 +170,7 @@ func (h *Handler) ConnectionExecute(connID core.ConnectionID, query string) (*co
 		h.events.CallStateChanged(c)
 	})
 
+	call.SetCallersWinID(callersWinID)
 	id := call.GetID()
 
 	// add to lookup

--- a/dbee/handler/marshal.go
+++ b/dbee/handler/marshal.go
@@ -40,19 +40,21 @@ func (cw *callWrap) MarshalMsgPack(enc *msgpack.Encoder) error {
 	}
 
 	return enc.Encode(&struct {
-		ID        string `msgpack:"id"`
-		Query     string `msgpack:"query"`
-		State     string `msgpack:"state"`
-		TimeTaken int64  `msgpack:"time_taken_us"`
-		Timestamp int64  `msgpack:"timestamp_us"`
-		Error     string `msgpack:"error,omitempty"`
+		ID           string `msgpack:"id"`
+		Query        string `msgpack:"query"`
+		CallersWinID uint64 `msgpack:"callers_winid"`
+		State        string `msgpack:"state"`
+		TimeTaken    int64  `msgpack:"time_taken_us"`
+		Timestamp    int64  `msgpack:"timestamp_us"`
+		Error        string `msgpack:"error,omitempty"`
 	}{
-		ID:        string(cw.call.GetID()),
-		Query:     cw.call.GetQuery(),
-		State:     cw.call.GetState().String(),
-		TimeTaken: cw.call.GetTimeTaken().Microseconds(),
-		Timestamp: cw.call.GetTimestamp().UnixMicro(),
-		Error:     errMsg,
+		ID:           string(cw.call.GetID()),
+		Query:        cw.call.GetQuery(),
+		State:        cw.call.GetState().String(),
+		CallersWinID: cw.call.GetCallersWinID(),
+		TimeTaken:    cw.call.GetTimeTaken().Microseconds(),
+		Timestamp:    cw.call.GetTimestamp().UnixMicro(),
+		Error:        errMsg,
 	})
 }
 

--- a/doc/dbee-reference.txt
+++ b/doc/dbee-reference.txt
@@ -227,6 +227,8 @@ CallDetails                                                        *CallDetails*
     Fields: ~
         {id}             (call_id)
         {time_taken_us}  (integer)     duration (time period) in microseconds
+        {callers_winid}  (integer)     the winid the curser was on when the
+	call was made
         {query}          (string)
         {state}          (call_state)
         {timestamp_us}   (integer)     time in microseconds

--- a/lua/dbee.lua
+++ b/lua/dbee.lua
@@ -70,7 +70,7 @@ function dbee.execute(query)
     error("no connection currently selected")
   end
 
-  local call = api.core.connection_execute(conn.id, query)
+  local call = api.core.connection_execute(conn.id, query, 0)
   api.ui.result_set_call(call)
 
   dbee.open()

--- a/lua/dbee/api/core.lua
+++ b/lua/dbee/api/core.lua
@@ -116,10 +116,10 @@ end
 ---Execute a query on a connection.
 ---@param id connection_id
 ---@param query string
----@param winID integer
+---@param winid integer
 ---@return CallDetails
-function core.connection_execute(id, query, winID)
-  return state.handler():connection_execute(id, query, winID)
+function core.connection_execute(id, query, winid)
+  return state.handler():connection_execute(id, query, winid)
 end
 
 ---Get database structure of a connection.

--- a/lua/dbee/api/core.lua
+++ b/lua/dbee/api/core.lua
@@ -116,9 +116,10 @@ end
 ---Execute a query on a connection.
 ---@param id connection_id
 ---@param query string
+---@param winID integer
 ---@return CallDetails
-function core.connection_execute(id, query)
-  return state.handler():connection_execute(id, query)
+function core.connection_execute(id, query, winID)
+  return state.handler():connection_execute(id, query, winID)
 end
 
 ---Get database structure of a connection.

--- a/lua/dbee/doc.lua
+++ b/lua/dbee/doc.lua
@@ -53,6 +53,7 @@
 ---@field id call_id
 ---@field time_taken_us integer duration (time period) in microseconds
 ---@field query string
+---@field callers_windid integer time in microseconds
 ---@field state call_state
 ---@field timestamp_us integer time in microseconds
 ---@field error? string error message in case of error

--- a/lua/dbee/handler/init.lua
+++ b/lua/dbee/handler/init.lua
@@ -212,9 +212,10 @@ end
 
 ---@param id connection_id
 ---@param query string
+---@param winid integer
 ---@return CallDetails
-function Handler:connection_execute(id, query, winID)
-  return vim.fn.DbeeConnectionExecute(id, query, winID)
+function Handler:connection_execute(id, query, winid)
+  return vim.fn.DbeeConnectionExecute(id, query, winid)
 end
 
 ---@param id connection_id

--- a/lua/dbee/handler/init.lua
+++ b/lua/dbee/handler/init.lua
@@ -213,8 +213,8 @@ end
 ---@param id connection_id
 ---@param query string
 ---@return CallDetails
-function Handler:connection_execute(id, query)
-  return vim.fn.DbeeConnectionExecute(id, query)
+function Handler:connection_execute(id, query, winID)
+  return vim.fn.DbeeConnectionExecute(id, query, winID)
 end
 
 ---@param id connection_id

--- a/lua/dbee/ui/call_log.lua
+++ b/lua/dbee/ui/call_log.lua
@@ -283,6 +283,7 @@ function CallLogUI:configure_preview(bufnr)
       local call_summary = {
         { key = "id", value = call.id },
         { key = "query", value = string.gsub(call.query, "\n", " ") },
+        { key = "callers_winid", value = call.callers_windid},
         { key = "state", value = call.state },
         { key = "time_taken", value = string.format("%.3f seconds", (call.time_taken_us or 0) / 1000000) },
         { key = "timestamp", value = tostring(os.date("%c", (call.timestamp_us or 0) / 1000000)) },

--- a/lua/dbee/ui/drawer/convert.lua
+++ b/lua/dbee/ui/drawer/convert.lua
@@ -67,7 +67,7 @@ local function connection_nodes(handler, conn, result)
             title = "Select a Query",
             items = items,
             on_confirm = function(selection)
-              local call = handler:connection_execute(conn.id, helpers[selection])
+              local call = handler:connection_execute(conn.id, helpers[selection], 0)
               result:set_call(call)
               cb()
             end,

--- a/lua/dbee/ui/editor/init.lua
+++ b/lua/dbee/ui/editor/init.lua
@@ -140,7 +140,8 @@ function EditorUI:get_actions()
       if not conn then
         return
       end
-      local call = self.handler:connection_execute(conn.id, query)
+      local current_winid = vim.api.nvim_get_current_win()
+      local call = self.handler:connection_execute(conn.id, query, current_winid)
       self.result:set_call(call)
     end,
     run_selection = function()
@@ -153,7 +154,8 @@ function EditorUI:get_actions()
       if not conn then
         return
       end
-      local call = self.handler:connection_execute(conn.id, query)
+      local current_winid = vim.api.nvim_get_current_win()
+      local call = self.handler:connection_execute(conn.id, query, current_winid)
       self.result:set_call(call)
     end,
   }

--- a/lua/dbee/ui/result/init.lua
+++ b/lua/dbee/ui/result/init.lua
@@ -74,7 +74,6 @@ end
 ---@private
 ---@param data { call: CallDetails }
 function ResultUI:on_call_state_changed(data)
-  vim.notify(vim.inspect({ "data", data }))
   local call = data.call
 
   -- we only care about the current call
@@ -292,27 +291,22 @@ function ResultUI:get_call()
 end
 
 function ResultUI:page_current()
-  vim.notify("1")
   self.page_index = self:display_result(self.page_index)
 end
 
 function ResultUI:page_next()
-  vim.notify("2")
   self.page_index = self:display_result(self.page_index + 1)
 end
 
 function ResultUI:page_prev()
-  vim.notify("3")
   self.page_index = self:display_result(self.page_index - 1)
 end
 
 function ResultUI:page_last()
-  vim.notify("4")
   self.page_index = self:display_result(self.page_ammount)
 end
 
 function ResultUI:page_first()
-  vim.notify("5")
   self.page_index = self:display_result(self.page_ammount)
   self.page_index = self:display_result(0)
 end
@@ -452,7 +446,6 @@ end
 
 ---@param winid integer
 function ResultUI:show(winid)
-  vim.notify("show")
   self.winid = self.focus_result and winid or 0
 
   -- configure window highlights

--- a/lua/dbee/ui/result/init.lua
+++ b/lua/dbee/ui/result/init.lua
@@ -74,6 +74,7 @@ end
 ---@private
 ---@param data { call: CallDetails }
 function ResultUI:on_call_state_changed(data)
+  vim.notify(vim.inspect({ "data", data }))
   local call = data.call
 
   -- we only care about the current call
@@ -97,6 +98,7 @@ function ResultUI:on_call_state_changed(data)
   else
     self.stop_progress()
   end
+  vim.api.nvim_set_current_win(data.call.callers_winid)
 end
 
 ---@private
@@ -290,22 +292,28 @@ function ResultUI:get_call()
 end
 
 function ResultUI:page_current()
+  vim.notify("1")
   self.page_index = self:display_result(self.page_index)
 end
 
 function ResultUI:page_next()
+  vim.notify("2")
   self.page_index = self:display_result(self.page_index + 1)
 end
 
 function ResultUI:page_prev()
+  vim.notify("3")
   self.page_index = self:display_result(self.page_index - 1)
 end
 
 function ResultUI:page_last()
+  vim.notify("4")
   self.page_index = self:display_result(self.page_ammount)
 end
 
 function ResultUI:page_first()
+  vim.notify("5")
+  self.page_index = self:display_result(self.page_ammount)
   self.page_index = self:display_result(0)
 end
 
@@ -444,6 +452,7 @@ end
 
 ---@param winid integer
 function ResultUI:show(winid)
+  vim.notify("show")
   self.winid = self.focus_result and winid or 0
 
   -- configure window highlights


### PR DESCRIPTION
After exexuting a query, the curser is on the `results window` - this is quite irritating I maybe crafting a query which is an iterative task and I have to manually move back to the query window.

This change will make it so the curser will go back to which ever window the query was called from