### PR TITLE
chore: bigquery refactoring and CI/CD update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,6 @@
 name: Testing
 
 on:
-  workflow_dispatch: # allow manual invocation of this workflow (e.g. integration tests)
   pull_request:
   push:
     branches: [master]
@@ -34,7 +33,6 @@ jobs:
         run: go test $(go list ./... | grep -v tests) -v
 
   bootstrap-testcontainers:
-    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-22.04
     name: Bootstrap Testcontainers
     outputs:

--- a/dbee/adapters/bigquery.go
+++ b/dbee/adapters/bigquery.go
@@ -102,7 +102,7 @@ func (bq *BigQuery) Connect(rawURL string) (core.Driver, error) {
 
 func (*BigQuery) GetHelpers(opts *core.TableOptions) map[string]string {
 	return map[string]string{
-		"List":    fmt.Sprintf("SELECT * FROM `%s` LIMIT 500", opts.Table),
+		"List":    fmt.Sprintf("SELECT * FROM `%s` TABLESAMPLE SYSTEM (5 PERCENT)", opts.Table),
 		"Columns": fmt.Sprintf("SELECT * FROM `%s.INFORMATION_SCHEMA.COLUMNS` WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s'", opts.Schema, opts.Schema, opts.Table),
 	}
 }


### PR DESCRIPTION
some QoL stuff

- bigquery charges of the underlying tables size, not processed data -> ergo `LIMIT` doesn't apply, change to specific for bigquery
- run containers on PRs/pushes on `master`