### PR TITLE
hotfix: Add focus result window function

### DIFF
--- a/lua/dbee/ui/result/init.lua
+++ b/lua/dbee/ui/result/init.lua
@@ -119,11 +119,18 @@ function ResultUI:has_window()
 end
 
 ---@private
+function ResultUI:focus_result_window()
+  if self.focus_result then
+    return vim.api.nvim_set_current_win(self.winid)
+  end
+end
+
+---@private
 function ResultUI:display_progress()
   self.stop_progress = progress.display(self.bufnr, self.progress_opts)
 
   if self:has_window() then
-    vim.api.nvim_set_current_win(self.winid)
+    self:focus_result_window()
   end
 end
 
@@ -163,7 +170,7 @@ function ResultUI:display_status()
   -- set winbar and set focus
   if self:has_window() then
     vim.api.nvim_win_set_option(self.winid, "winbar", "Results")
-    vim.api.nvim_set_current_win(self.winid)
+    self:focus_result_window()
   end
 
   -- reset modified flag
@@ -209,7 +216,7 @@ function ResultUI:display_result(page)
     )
 
     -- set focus if window exists
-    vim.api.nvim_set_current_win(self.winid)
+    self:focus_result_window()
   end
 
   -- reset modified flag
@@ -444,7 +451,7 @@ end
 
 ---@param winid integer
 function ResultUI:show(winid)
-  self.winid = self.focus_result and winid or 0
+  self.winid = winid
 
   -- configure window highlights
   self:apply_highlight(self.winid)

--- a/lua/dbee/ui/result/init.lua
+++ b/lua/dbee/ui/result/init.lua
@@ -120,7 +120,7 @@ end
 
 ---@private
 function ResultUI:focus_result_window()
-  if self.focus_result then
+  if self.focus_result and self:has_window() then
     return vim.api.nvim_set_current_win(self.winid)
   end
 end
@@ -128,10 +128,6 @@ end
 ---@private
 function ResultUI:display_progress()
   self.stop_progress = progress.display(self.bufnr, self.progress_opts)
-
-  if self:has_window() then
-    self:focus_result_window()
-  end
 end
 
 ---@private
@@ -167,10 +163,9 @@ function ResultUI:display_status()
 
   vim.api.nvim_buf_set_option(self.bufnr, "modifiable", false)
 
-  -- set winbar and set focus
+  -- set winbar
   if self:has_window() then
     vim.api.nvim_win_set_option(self.winid, "winbar", "Results")
-    self:focus_result_window()
   end
 
   -- reset modified flag
@@ -214,10 +209,9 @@ function ResultUI:display_result(page)
       "winbar",
       string.format("%d/%d (%d)%%=Took %.3fs", page + 1, self.page_ammount + 1, length, seconds)
     )
-
-    -- set focus if window exists
-    self:focus_result_window()
   end
+  -- set focus if window exists
+  self:focus_result_window()
 
   -- reset modified flag
   vim.api.nvim_buf_set_option(self.bufnr, "modified", false)

--- a/lua/dbee/ui/result/init.lua
+++ b/lua/dbee/ui/result/init.lua
@@ -126,6 +126,13 @@ function ResultUI:focus_result_window()
 end
 
 ---@private
+function ResultUI:set_default_result_window()
+  if self:has_window() then
+    vim.api.nvim_win_set_option(self.winid, "winbar", "Results")
+  end
+end
+
+---@private
 function ResultUI:display_progress()
   self.stop_progress = progress.display(self.bufnr, self.progress_opts)
 end
@@ -164,9 +171,7 @@ function ResultUI:display_status()
   vim.api.nvim_buf_set_option(self.bufnr, "modifiable", false)
 
   -- set winbar
-  if self:has_window() then
-    vim.api.nvim_win_set_option(self.winid, "winbar", "Results")
-  end
+  self:set_default_result_window()
 
   -- reset modified flag
   vim.api.nvim_buf_set_option(self.bufnr, "modified", false)
@@ -461,7 +466,7 @@ function ResultUI:show(winid)
   -- display the current result
   local ok = pcall(self.page_current, self)
   if not ok then
-    vim.api.nvim_win_set_option(self.winid, "winbar", "Results")
+    self:set_default_result_window()
   end
 end
 


### PR DESCRIPTION
This is to add more control to the result focus window step. This is needed to mitigate the window title being added for the "Results" winbar.

This is to fix https://github.com/kndndrj/nvim-dbee/pull/167

Before:
<img width="858" alt="Screenshot 2025-03-24 at 14 45 51" src="https://github.com/user-attachments/assets/80ced5ce-65a4-44c2-b712-0cd9a48d405e" />
After this change:
<img width="865" alt="Screenshot 2025-03-24 at 14 45 16" src="https://github.com/user-attachments/assets/95f0b9fe-ffb7-4149-ab8c-b8265d2340f8" />
