### PR TITLE
feat(editor): add run_under_cursor

### DIFF
--- a/lua/dbee/config.lua
+++ b/lua/dbee/config.lua
@@ -269,6 +269,8 @@ config.default = {
       { key = "BB", mode = "v", action = "run_selection" },
       -- run the whole file on the active connection
       { key = "BB", mode = "n", action = "run_file" },
+      -- run what's under the cursor to the next newline
+      { key = "<CR>", mode = "n", action = "run_under_cursor" },
     },
   },
 

--- a/lua/dbee/ui/editor/init.lua
+++ b/lua/dbee/ui/editor/init.lua
@@ -156,6 +156,33 @@ function EditorUI:get_actions()
       local call = self.handler:connection_execute(conn.id, query)
       self.result:set_call(call)
     end,
+    run_under_cursor = function()
+      local bufnr = vim.api.nvim_get_current_buf()
+      local query, srow, erow = utils.query_under_cursor(bufnr)
+
+      if query ~= "" then
+        -- highlight the statement that will be executed
+        local ns_id = vim.api.nvim_create_namespace("dbee_query_highlight")
+        vim.api.nvim_buf_clear_namespace(bufnr, ns_id, 0, -1)
+        vim.api.nvim_buf_set_extmark(bufnr, ns_id, srow, 0, {
+          end_row = erow + 1,
+          end_col = 0,
+          hl_group = "DiffText",
+          priority = 100,
+        })
+
+        -- run the query
+        local conn = self.handler:get_current_connection()
+        if conn then
+          self.result:set_call(self.handler:connection_execute(conn.id, query))
+        end
+
+        -- remove highlighting after delay
+        vim.defer_fn(function()
+          vim.api.nvim_buf_clear_namespace(bufnr, ns_id, 0, -1)
+        end, 750)
+      end
+    end,
   }
 end
 

--- a/lua/dbee/utils.lua
+++ b/lua/dbee/utils.lua
@@ -159,4 +159,55 @@ function M.random_string()
   return r(10)
 end
 
+--- Get the SQL statement under the cursor and its range (using treesitter).
+--- Potential returns are 1. the SQL query, 2. empty string, 3. nil if filetype isn't SQL.
+---@param bufnr integer buffer containing the SQL queries.
+---@return nil|string query, nil|integer start_row, nil|integer end_row
+function M.query_under_cursor(bufnr)
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+  local ft = vim.bo[bufnr].filetype
+  if ft ~= "sql" then
+    return
+  end
+
+  local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  local cursor_row = vim.api.nvim_win_get_cursor(0)[1] - 1
+  local query = ""
+  local start_row, end_row = 0, 0
+
+  -- tmp_buf is a temporary buffer for treesitter to parse the SQL statements
+  local tmp_buf = vim.api.nvim_create_buf(false, true)
+
+  -- replace empty lines with semicolons to make sure treesitter parse them
+  -- as statement (still supports newlines between CTEs)
+  local content = vim.tbl_map(function(line)
+    return line ~= "" and line or ";"
+  end, lines)
+
+  vim.api.nvim_buf_set_lines(tmp_buf, 0, -1, false, content)
+
+  local parser = vim.treesitter.get_parser(tmp_buf, "sql", {})
+  if not parser then
+    vim.api.nvim_buf_delete(tmp_buf, { force = true })
+    return query, start_row, end_row
+  end
+
+  local root = parser:parse()[1]:root()
+
+  for node in root:iter_children() do
+    if node:type() == "statement" then
+      local node_start_row, _, node_end_row, _ = node:range()
+      if cursor_row >= node_start_row and cursor_row <= node_end_row then
+        query = vim.treesitter.get_node_text(node, tmp_buf)
+        start_row, end_row = node_start_row, node_end_row
+        break
+      end
+    end
+  end
+
+  -- clean up the tmp_buf
+  vim.api.nvim_buf_delete(tmp_buf, { force = true })
+  return query:gsub(";", ""), start_row, end_row
+end
+
 return M


### PR DESCRIPTION
~edit: I'll try to add treesitter into this as per https://github.com/MattiasMTS/cmp-dbee/blob/ms/v2/lua/cmp-dbee/treesitter/init.lua to support when one is running more complex queries, e.g. multiple CTEs.~ 
**EDIT2:** solved, added treesitter to support more complex queries.

Solves #121. As per the discussions in that thread, there are various ways to do this.

We can discuss wether we want this to be ported into the `main` or just be part of discussion somewhere. It definitely improve the UX a bit - similar to Jetbrain's datagrip style.

Video:
**EDIT2:** uploaded new file with more complex queries


https://github.com/user-attachments/assets/e790897a-32f5-49f9-9d61-6edca4e06aca


