### PR TITLE
feat(editor): Add reset option to dbee open

### DIFF
--- a/dbee/tests/testhelpers/sqlite.go
+++ b/dbee/tests/testhelpers/sqlite.go
@@ -34,7 +34,7 @@ func NewSQLiteContainer(ctx context.Context, params *core.ConnectionParams, tmpD
 
 	dbName, containerDBPath := "test.db", "/container/db"
 	entrypointCmd := []string{
-		"apk add sqlite=3.48.0-r0",
+		"apk add sqlite",
 		fmt.Sprintf("sqlite3 %s/%s < %s", containerDBPath, dbName, seedFile.Name()),
 		"echo 'ready'",
 		"tail -f /dev/null", // hack to keep the container running indefinitely

--- a/lua/dbee.lua
+++ b/lua/dbee.lua
@@ -38,10 +38,10 @@ function dbee.toggle()
   end
 end
 
----Open dbee UI.
+---Open dbee UI. If already opened, reset window layout.
 function dbee.open()
   if api.current_config().window_layout:is_open() then
-    return
+    return api.current_config().window_layout:reset()
   end
   api.current_config().window_layout:open()
 end


### PR DESCRIPTION
~~Adds options to the `require('dbee').open( { reset = true } )`,~~ which will reset the windows to the fixed size defined in layout config.
The reset functionality is now build into the `require('dbee').open()`, such that:
1. If not yet open, it will open
2. If open, it will reset the layout

A question is if we want it to be hard coded, or dynamically calculated relative to the terminal current size. Any thoughts @MattiasMTS?

## Left to do:
- [x] Update to documentation