### PR TITLE
fix: explicitly set the `sql` filetype on new notes

### DIFF
--- a/lua/dbee/ui/editor/init.lua
+++ b/lua/dbee/ui/editor/init.lua
@@ -47,6 +47,7 @@ function EditorUI:new(handler, result, opts)
     buffer_options = vim.tbl_extend("force", {
       buflisted = false,
       swapfile = false,
+      filetype = "sql",
     }, opts.buffer_options or {}),
   }
   setmetatable(o, self)


### PR DESCRIPTION
This fixes https://github.com/kndndrj/nvim-dbee/issues/154.

For some reason, when creating a new note (local or global), the filetype for the new buffer was being set to `sql`, but treesitter wasn't picking up the filetype for syntax highlighting.

This is a bit of a hack, but I found that explicitly setting the filetype to `sql` on the buffer seems to resolve the issue 🤷 