### PR TITLE
fix: ensure that local notes are loaded properly from disk

### DIFF
--- a/lua/dbee/sources.lua
+++ b/lua/dbee/sources.lua
@@ -101,7 +101,7 @@ function sources.FileSource:create(conn)
   -- read from file
   local existing = self:load()
 
-  conn.id = "file_source_" .. self.path .. utils.random_string()
+  conn.id = "file_source_/" .. utils.random_string()
   table.insert(existing, conn)
 
   -- write back to file


### PR DESCRIPTION
Before this PR, the app would attempt to eagerly load all global and local notes from disk. Unfortunately, there was a bug in the algorithm, such that it would load ONLY global notes (and not local notes).

Rather than fix the bug in the "eager-loading" strategy, I think it would be easier to switch to a "lazy-loading" strategy, i.e. lazily load notes from disk, per-namespace. This also ends up fixing the original bug.

This should resolve https://github.com/kndndrj/nvim-dbee/issues/151.

Tested locally.