### PR TITLE
fix(tests): relax sqlite version

### DIFF
--- a/dbee/tests/testhelpers/sqlite.go
+++ b/dbee/tests/testhelpers/sqlite.go
@@ -34,7 +34,7 @@ func NewSQLiteContainer(ctx context.Context, params *core.ConnectionParams, tmpD
 
 	dbName, containerDBPath := "test.db", "/container/db"
 	entrypointCmd := []string{
-		"apk add sqlite=3.48.0-r1",
+		"apk add sqlite",
 		fmt.Sprintf("sqlite3 %s/%s < %s", containerDBPath, dbName, seedFile.Name()),
 		"echo 'ready'",
 		"tail -f /dev/null", // hack to keep the container running indefinitely


### PR DESCRIPTION
Relax the version of `sqlite` on `alpine:3.21`. Should probably be locked soon ones alpine is done iterating on this version.