### PR TITLE
fix: edit clickhouse driver query's

### DIFF
--- a/dbee/adapters/clickhouse_driver.go
+++ b/dbee/adapters/clickhouse_driver.go
@@ -36,15 +36,24 @@ func (c *clickhouseDriver) Columns(opts *core.TableOptions) ([]*core.Column, err
 
 func (c *clickhouseDriver) Structure() ([]*core.Structure, error) {
 	query := `
-        SELECT
-            table_schema, table_name, table_type
-            FROM information_schema.tables
-            WHERE lower(table_schema) != 'information_schema'
-        UNION ALL
-        SELECT DISTINCT
-            lower(table_schema), lower(table_name), table_type
-            FROM information_schema.tables
-            WHERE lower(table_schema) = 'information_schema'`
+		SELECT
+			database AS table_schema,
+			name AS table_name,
+			CASE
+				WHEN engine IN (
+					'MergeTree', 'ReplacingMergeTree', 'SummingMergeTree', 'AggregatingMergeTree',
+					'CollapsingMergeTree', 'VersionedCollapsingMergeTree', 'GraphiteMergeTree',
+					'TinyLog', 'Log', 'StripeLog', 'Memory', 'Buffer', 'Distributed'
+				) THEN 'BASE TABLE'
+				WHEN engine = 'View' THEN 'VIEW'
+				WHEN engine = 'MaterializedView' THEN 'VIEW'
+				WHEN engine = 'LiveView' THEN 'VIEW'
+				WHEN database IN ('system', 'information_schema') THEN 'SYSTEM TABLE'
+				ELSE 'UNKNOWN'
+			END AS table_type
+		FROM system.tables
+		ORDER BY database, name
+		`
 
 	rows, err := c.Query(context.TODO(), query)
 	if err != nil {
@@ -60,9 +69,11 @@ func (c *clickhouseDriver) Close() {
 
 func (c *clickhouseDriver) ListDatabases() (current string, available []string, err error) {
 	query := `
-		SELECT currentDatabase(), schema_name
-        FROM information_schema.schemata
-        WHERE schema_name NOT IN (currentDatabase(), 'INFORMATION_SCHEMA')
+		SELECT
+    		currentDatabase() AS current_db,
+    		name AS schema_name
+		FROM system.databases
+		WHERE name NOT IN (currentDatabase(), 'INFORMATION_SCHEMA')
 	`
 
 	rows, err := c.Query(context.TODO(), query)


### PR DESCRIPTION
I have found the use of unstable methods for obtaining a list of tables and information about them, especially in conditions of limited access. 
propose a more optimal and universal solution.