### PR TITLE
feat(layout): expose function and command to toggle visibility of sidebar (drawer + call_log windows)

### DIFF
--- a/lua/dbee.lua
+++ b/lua/dbee.lua
@@ -54,6 +54,13 @@ function dbee.close()
   api.current_config().window_layout:close()
 end
 
+--Toggle dbee sidebar (drawer and call_log windows).
+function dbee.sidebar_toggle()
+  if api.current_config().window_layout:is_open() then
+    api.current_config().window_layout:sidebar_toggle()
+  end
+end
+
 ---Check if dbee UI is open or not.
 ---@return boolean
 function dbee.is_open()

--- a/lua/dbee/api/ui.lua
+++ b/lua/dbee/api/ui.lua
@@ -163,7 +163,7 @@ end
 
 --- Toggle the sidebar UI (drawer and call_log).
 function ui.sidebar_toggle()
-  state.config().window_layout:toggle_sidebar()
+  state.config().window_layout:sidebar_toggle()
 end
 
 --- Trigger an action in drawer.

--- a/lua/dbee/api/ui.lua
+++ b/lua/dbee/api/ui.lua
@@ -161,6 +161,11 @@ function ui.drawer_show(winid)
   state.drawer():show(winid)
 end
 
+--- Toggle the sidebar UI (drawer and call_log).
+function ui.sidebar_toggle()
+  state.config().window_layout:toggle_sidebar()
+end
+
 --- Trigger an action in drawer.
 ---@param action string
 function ui.drawer_do_action(action)

--- a/lua/dbee/layouts/init.lua
+++ b/lua/dbee/layouts/init.lua
@@ -22,6 +22,7 @@ local api_ui = require("dbee.api.ui")
 ---@field open fun(self: Layout) function to open ui.
 ---@field reset fun(self: Layout) function to reset ui.
 ---@field close fun(self: Layout) function to close ui.
+---@field toggle_sidebar fun(self: Layout) function to toggle the sidebar (drawer and call log) visibility.
 
 local layouts = {}
 
@@ -190,6 +191,35 @@ function layouts.Default:close()
   tools.restore(self.egg)
   self.egg = nil
   self.is_opened = false
+end
+
+---@package
+function layouts.Default:toggle_sidebar()
+  --drawer
+  if self.windows["drawer"] then
+    vim.api.nvim_win_close(self.windows["drawer"], true)
+    self.windows["drawer"] = nil
+  else
+    vim.cmd("to" .. self.drawer_width .. "vsplit")
+    local win = vim.api.nvim_get_current_win()
+    self.windows["drawer"] = win
+    api_ui.drawer_show(win)
+    self:configure_window_on_switch(self.on_switch, win, api_ui.drawer_show)
+    self:configure_window_on_quit(win)
+  end
+
+  -- call log
+  if self.windows["call_log"] then
+    vim.api.nvim_win_close(self.windows["call_log"], true)
+    self.windows["call_log"] = nil
+  else
+    vim.cmd("belowright " .. self.call_log_height .. "split")
+    local win = vim.api.nvim_get_current_win()
+    self.windows["call_log"] = win
+    api_ui.call_log_show(win)
+    self:configure_window_on_switch(self.on_switch, win, api_ui.call_log_show)
+    self:configure_window_on_quit(win)
+  end
 end
 
 return layouts

--- a/lua/dbee/layouts/init.lua
+++ b/lua/dbee/layouts/init.lua
@@ -22,7 +22,7 @@ local api_ui = require("dbee.api.ui")
 ---@field open fun(self: Layout) function to open ui.
 ---@field reset fun(self: Layout) function to reset ui.
 ---@field close fun(self: Layout) function to close ui.
----@field toggle_sidebar fun(self: Layout) function to toggle the sidebar (drawer and call log) visibility.
+---@field sidebar_toggle fun(self: Layout) function to toggle the sidebar (drawer and call log) visibility.
 
 local layouts = {}
 
@@ -194,18 +194,18 @@ function layouts.Default:close()
 end
 
 ---@package
-function layouts.Default:toggle_sidebar()
+function layouts.Default:sidebar_toggle()
   --drawer
   if self.windows["drawer"] then
     vim.api.nvim_win_close(self.windows["drawer"], true)
     self.windows["drawer"] = nil
   else
     vim.cmd("to" .. self.drawer_width .. "vsplit")
-    local win = vim.api.nvim_get_current_win()
-    self.windows["drawer"] = win
-    api_ui.drawer_show(win)
-    self:configure_window_on_switch(self.on_switch, win, api_ui.drawer_show)
-    self:configure_window_on_quit(win)
+    local drawer_win = vim.api.nvim_get_current_win()
+    self.windows["drawer"] = drawer_win
+    api_ui.drawer_show(drawer_win)
+    self:configure_window_on_switch(self.on_switch, drawer_win, api_ui.drawer_show)
+    self:configure_window_on_quit(drawer_win)
   end
 
   -- call log
@@ -214,11 +214,13 @@ function layouts.Default:toggle_sidebar()
     self.windows["call_log"] = nil
   else
     vim.cmd("belowright " .. self.call_log_height .. "split")
-    local win = vim.api.nvim_get_current_win()
-    self.windows["call_log"] = win
-    api_ui.call_log_show(win)
-    self:configure_window_on_switch(self.on_switch, win, api_ui.call_log_show)
-    self:configure_window_on_quit(win)
+    local call_log_win = vim.api.nvim_get_current_win()
+    self.windows["call_log"] = call_log_win
+    api_ui.call_log_show(call_log_win)
+    self:configure_window_on_switch(self.on_switch, call_log_win, api_ui.call_log_show)
+    self:configure_window_on_quit(call_log_win)
+    -- set cursor to drawer
+    vim.api.nvim_set_current_win(self.windows["drawer"])
   end
 end
 

--- a/plugin/dbee.lua
+++ b/plugin/dbee.lua
@@ -9,6 +9,7 @@ local commands = {
   open = require("dbee").open,
   close = require("dbee").close,
   toggle = require("dbee").toggle,
+  sidebarToggle = require("dbee").sidebar_toggle,
   execute = function(args)
     require("dbee").execute(table.concat(args, " "))
   end,


### PR DESCRIPTION
## Motivation

When working within the same database connection, the sidebar containing the drawer and call log windows might not always be needed opened. Toggling it off can be used to open up some space to some focus work with the editor and results windows.

## What was done

A function to toggle the visibility of the sidebar (drawer + call_log windows simultaneously) is exposed through `require("dbee").sidebar_toggle()` or through the command `:Dbee sidebarToggle`. 

https://github.com/user-attachments/assets/b3f7895e-be03-4bdf-ab51-2e02688cc7c4

Closes #223 

## Potential issues

- If the height and width of the windows to be hidden are changed before they are toggled off, when you toggle the sidebar back on, the height and width of the windows will be reset to the default values;
- If there are any expanded database nodes (showing schemas/tables) before the sidebar is toggled off, when the sidebar is toggled back on, the UI will lag for a bit before displaying the sidebar because the databases tables are refetched. This might be possible to solve by implementing some sort of loading state on these nodes.