### PR TITLE
fix(oracle): Corrections in node expansion and Column helper for oracle database

### DIFF
--- a/dbee/adapters/oracle.go
+++ b/dbee/adapters/oracle.go
@@ -69,9 +69,6 @@ func (*Oracle) GetHelpers(opts *core.TableOptions) map[string]string {
 				col.data_scale,
 				col.nullable
 			FROM sys.all_tab_columns col
-			INNER JOIN sys.all_tables t
-				ON col.owner = t.owner
-				AND col.table_name = t.table_name
 			WHERE col.owner = '%s'
 				AND col.table_name = '%s'
 			ORDER BY col.owner, col.table_name, col.column_id `,

--- a/dbee/adapters/oracle_driver.go
+++ b/dbee/adapters/oracle_driver.go
@@ -34,9 +34,6 @@ func (d *oracleDriver) Columns(opts *core.TableOptions) ([]*core.Column, error) 
 			col.column_name,
 			col.data_type
 		FROM sys.all_tab_columns col
-		INNER JOIN sys.all_tables t
-			ON col.owner = t.owner
-			AND col.table_name = t.table_name
 		WHERE col.owner = '%s'
 			AND col.table_name = '%s'
 		ORDER BY col.owner, col.table_name, col.column_id `,


### PR DESCRIPTION
## Motivation

There was a bug when expanding database>view nodes to see column names, as well as using the "Columns" helper to query for View's columns.

## What was done

In the SQL code fetching for Columns, there was an INNER JOIN to the all_tables table that limited the query results to only Table data structures. Since we have all the needed information in the all_tab_columns table, we do not need to Join with the all_tables table, allowing for Views and Materialized Views to also be returned in the query.

<img width="1342" height="712" alt="image" src="https://github.com/user-attachments/assets/d7a037d6-8a2c-465f-9a79-9bc7934cfb37" />

Closes #222 