### PR TITLE
feat(oracle): add declaration helper to show creation ddl of tables and views

### DIFF
--- a/dbee/adapters/oracle.go
+++ b/dbee/adapters/oracle.go
@@ -123,5 +123,21 @@ func (*Oracle) GetHelpers(opts *core.TableOptions) map[string]string {
 			opts.Schema,
 			opts.Table,
 		),
+		"Declaration": fmt.Sprintf(`
+			SELECT DBMS_METADATA.GET_DDL('%s', '%s', '%s') as declaration FROM DUAL`,
+
+			func(materialization core.StructureType) string {
+				switch materialization {
+				case core.StructureTypeTable:
+					return "TABLE"
+				case core.StructureTypeView:
+					return "VIEW"
+				default:
+					return "UNKNOWN"
+				}
+			}(opts.Materialization),
+			opts.Table,
+			opts.Schema,
+		),
 	}
 }

--- a/dbee/adapters/oracle.go
+++ b/dbee/adapters/oracle.go
@@ -132,6 +132,8 @@ func (*Oracle) GetHelpers(opts *core.TableOptions) map[string]string {
 					return "TABLE"
 				case core.StructureTypeView:
 					return "VIEW"
+				case core.StructureTypeMaterializedView:
+					return "MATERIALIZED_VIEW"
 				default:
 					return "UNKNOWN"
 				}


### PR DESCRIPTION
## Motivation

When working with databases with many views, being able to see the creation DDL for that view or table can be very helpful. Personally , I use it mainly to change the declarations rules for a view or to help me define new migrations in the database.


## What was done

This is a proof of concept (using the oracle DB driver as an example) of how to implement a new helper query that can be used to show the DDL for tables, views or materialized views. In the future, it could be also implemented to other DB drivers gradually.

<img width="1344" height="709" alt="image" src="https://github.com/user-attachments/assets/e976a134-09d5-4f5d-8f9e-5cd7553254a8" />

Closes #226 
