### PR TITLE
fix: popup menu position and auto-close behavior

### DIFF
--- a/lua/dbee/ui/common/floats.lua
+++ b/lua/dbee/ui/common/floats.lua
@@ -295,6 +295,8 @@ function M.hover(relative_winid, contents, opts)
 
   -- row is relative to cursor in the "parent" window
   local cursor_row, _ = unpack(vim.api.nvim_win_get_cursor(relative_winid))
+  local first_visible_row = vim.fn.line("w0", relative_winid)
+  local row = cursor_row - first_visible_row
 
   -- open to left/right based on window position
   local col
@@ -317,7 +319,7 @@ function M.hover(relative_winid, contents, opts)
       width = opts.width,
       height = #lines,
       col = col,
-      row = cursor_row - 1,
+      row = row,
       anchor = anchor,
     }
   )

--- a/lua/dbee/ui/drawer/menu.lua
+++ b/lua/dbee/ui/drawer/menu.lua
@@ -1,5 +1,6 @@
 local NuiMenu = require("nui.menu")
 local NuiInput = require("nui.input")
+local event = require("nui.utils.autocmd").event
 
 local M = {}
 
@@ -85,6 +86,10 @@ function M.select(opts)
   end
 
   menu:mount()
+
+  menu:on(event.BufLeave, function()
+    menu:unmount()
+  end)
 end
 
 -- Ask for input.
@@ -150,6 +155,10 @@ function M.input(opts)
   end
 
   input:mount()
+
+  input:on(event.BufLeave, function()
+    input:unmount()
+  end)
 end
 
 return M

--- a/lua/dbee/ui/drawer/menu.lua
+++ b/lua/dbee/ui/drawer/menu.lua
@@ -15,7 +15,9 @@ function M.select(opts)
   end
 
   local width = vim.api.nvim_win_get_width(opts.relative_winid)
-  local row, _ = unpack(vim.api.nvim_win_get_cursor(opts.relative_winid))
+  local cursor_row, _ = unpack(vim.api.nvim_win_get_cursor(opts.relative_winid))
+  local first_visible_row = vim.fn.line("w0", opts.relative_winid)
+  local row = cursor_row - first_visible_row + 1
 
   local popup_options = {
     relative = {
@@ -93,7 +95,9 @@ function M.input(opts)
   end
 
   local width = vim.api.nvim_win_get_width(opts.relative_winid)
-  local row, _ = unpack(vim.api.nvim_win_get_cursor(opts.relative_winid))
+  local cursor_row, _ = unpack(vim.api.nvim_win_get_cursor(opts.relative_winid))
+  local first_visible_row = vim.fn.line("w0", opts.relative_winid)
+  local row = cursor_row - first_visible_row + 1
 
   local popup_options = {
     relative = {


### PR DESCRIPTION
Hi, this PR addresses an issue with popup positioning when the drawer is scrolled.
Happy to adjust if needed.

## Summary
- Fix popup (select, input, hover) position calculation to use window-relative coordinates instead of absolute buffer line numbers
- Add auto-close behavior for select/input popups on `BufLeave`

## Problem
When the drawer tree was scrolled down, popups appeared at incorrect positions because the position was calculated using the absolute cursor row in the buffer rather than the visible position within the window.

## Changes
- `floats.lua`: Calculate hover popup row relative to first visible line in window
- `menu.lua`: 
  - Same fix as `floats.lua` for select and input popups
  - Add `BufLeave` event handler to close popups when user navigates away

## Screenshots
before:
<img width="284" height="1033" alt="image" src="https://github.com/user-attachments/assets/9ae8ac12-d5fc-4779-9c28-fb079ac8447a" />

after:
<img width="288" height="674" alt="image" src="https://github.com/user-attachments/assets/868a47d5-2299-4061-9e87-ef941ad8510c" />
