### PR TITLE
fix(ui.drawer): BufModifiedSet deprecated fix

### DIFF
--- a/lua/dbee/ui/drawer/convert.lua
+++ b/lua/dbee/ui/drawer/convert.lua
@@ -364,10 +364,17 @@ local function modified_suffix(bufnr, refresh)
     suffix = " ●"
   end
 
-  utils.create_singleton_autocmd({ "OptionSet" }, {
-    pattern = "modified",
-    callback = refresh,
-  })
+  if vim.fn.has("nvim-0.13") == 1 then
+    utils.create_singleton_autocmd({ "OptionSet" }, {
+      pattern = "modified",
+      callback = refresh,
+    })
+  else
+    utils.create_singleton_autocmd({ "BufModifiedSet" }, {
+      buffer = bufnr,
+      callback = refresh,
+    })
+  end
 
   return suffix
 end

--- a/lua/dbee/ui/drawer/convert.lua
+++ b/lua/dbee/ui/drawer/convert.lua
@@ -366,9 +366,7 @@ local function modified_suffix(bufnr, refresh)
 
   utils.create_singleton_autocmd({ "OptionSet" }, {
     pattern = "modified",
-    callback = function(_)
-      refresh()
-    end,
+    callback = refresh,
   })
 
   return suffix

--- a/lua/dbee/ui/drawer/convert.lua
+++ b/lua/dbee/ui/drawer/convert.lua
@@ -364,9 +364,11 @@ local function modified_suffix(bufnr, refresh)
     suffix = " ●"
   end
 
-  utils.create_singleton_autocmd({ "BufModifiedSet" }, {
-    buffer = bufnr,
-    callback = refresh,
+  utils.create_singleton_autocmd({ "OptionSet" }, {
+    pattern = "modified",
+    callback = function(_)
+      refresh()
+    end,
   })
 
   return suffix


### PR DESCRIPTION
Fixes failure to open the ui in latest nightly due to BufModifiedSet deprecation.  I tested against the latest nightly and the behavior seems to match.

Fixes: #241 